### PR TITLE
matrix: fix typechecking of the multiplication operator under Python 3. Fixes #8

### DIFF
--- a/cairo/matrix.c
+++ b/cairo/matrix.c
@@ -108,6 +108,10 @@ matrix_multiply (PycairoMatrix *o, PyObject *args) {
 static PyObject *
 matrix_operator_multiply (PycairoMatrix *o, PycairoMatrix *o2) {
   cairo_matrix_t result;
+  if (PyObject_IsInstance((PyObject *)o2, (PyObject *)&PycairoMatrix_Type) <= 0) {
+    PyErr_SetString(PyExc_TypeError, "matrix can only multiply another matrix");
+    return NULL;
+  }
   cairo_matrix_multiply (&result, &o->matrix, &o2->matrix);
   return PycairoMatrix_FromMatrix (&result);
 }
@@ -326,7 +330,12 @@ PyTypeObject PycairoMatrix_Type = {
   0,                                  /* tp_getattro */
   0,                                  /* tp_setattro */
   0,                                  /* tp_as_buffer */
+#if PY_MAJOR_VERSION < 3
+  Py_TPFLAGS_DEFAULT |
+    Py_TPFLAGS_CHECKTYPES,            /* tp_flags */
+#else
   Py_TPFLAGS_DEFAULT,                 /* tp_flags */
+#endif
   NULL,                               /* tp_doc */
   0,                                  /* tp_traverse */
   0,                                  /* tp_clear */

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,6 +27,16 @@ def test_matrix():
     m.scale(1.5, 2.5)
     m.translate(10, 20)
 
+    with pytest.raises(TypeError):
+        m * 42
+
+    with pytest.raises(TypeError):
+        m + 42
+
+    assert m != 42
+    assert m == m
+    assert m != cairo.Matrix()
+
 
 def test_path():
     # AttributeError: 'module' object has no attribute 'Path'


### PR DESCRIPTION
Python 2 only allowed the same type there, but Python 3 will pass any object.

Add manual type checking and set Py_TPFLAGS_CHECKTYPES for Python 2 so we get
the same behaviour on both Python versions.

Based on a patch by Lawrence D'Oliveiro from
    https://bugs.freedesktop.org/show_bug.cgi?id=89162