### PR TITLE
surface: Add mime data support. Fixes #7

### DIFF
--- a/cairo/cairomodule.c
+++ b/cairo/cairomodule.c
@@ -520,6 +520,11 @@ PYCAIRO_MOD_INIT(_cairo)
 #else
   PyModule_AddIntConstant(m, "HAS_XLIB_SURFACE", 0);
 #endif
+#if CAIRO_HAS_MIME_SURFACE
+  PyModule_AddIntConstant(m, "HAS_MIME_SURFACE", 1);
+#else
+  PyModule_AddIntConstant(m, "HAS_MIME_SURFACE", 0);
+#endif
 
 #define CONSTANT(x) PyModule_AddIntConstant(m, #x, CAIRO_##x)
   CONSTANT(ANTIALIAS_DEFAULT);
@@ -676,6 +681,15 @@ PYCAIRO_MOD_INIT(_cairo)
   CONSTANT(STATUS_DEVICE_FINISHED);
   CONSTANT(STATUS_LAST_STATUS);
 
+#define STRCONSTANT(x) PyModule_AddStringConstant(m, #x, CAIRO_##x)
+
+  STRCONSTANT(MIME_TYPE_JP2);
+  STRCONSTANT(MIME_TYPE_JPEG);
+  STRCONSTANT(MIME_TYPE_PNG);
+  STRCONSTANT(MIME_TYPE_URI);
+  STRCONSTANT(MIME_TYPE_UNIQUE_ID);
+
+#undef STRCONSTANT
 #undef CONSTANT
 
 #if PY_MAJOR_VERSION >= 3

--- a/cairo/compat.h
+++ b/cairo/compat.h
@@ -44,6 +44,7 @@
 
 #define PYCAIRO_PyUnicode_FromString PyString_FromString
 #define PYCAIRO_PyUnicode_Join _PyString_Join
+#define PYCAIRO_PyUnicode_InternFromString PyString_InternFromString
 
 #define PYCAIRO_PyBytes_AsStringAndSize PyString_AsStringAndSize
 
@@ -63,6 +64,7 @@
 
 #define PYCAIRO_PyUnicode_FromString PyUnicode_FromString
 #define PYCAIRO_PyUnicode_Join PyUnicode_Join
+#define PYCAIRO_PyUnicode_InternFromString PyUnicode_InternFromString
 
 #define PYCAIRO_PyBytes_AsStringAndSize PyBytes_AsStringAndSize
 

--- a/docs/reference/constants.rst
+++ b/docs/reference/constants.rst
@@ -1,4 +1,4 @@
-.. _constants:
+<.. _constants:
 
 ******************************
 Module Functions and Constants
@@ -43,6 +43,9 @@ Module Constants
 
 cairo.HAS
 ---------
+
+1 if the feature is present in the underlying C cairo library, 0 otherwise.
+
 .. data:: HAS_ATSUI_FONT
           HAS_FT_FONT
           HAS_GLITZ_SURFACE
@@ -59,8 +62,9 @@ cairo.HAS
           HAS_XCB_SURFACE
           HAS_XLIB_SURFACE
 
-   1 if the feature is present in the underlying C cairo library,
-   0 otherwise
+.. data:: HAS_MIME_SURFACE
+
+    .. versionadded:: 1.12.0
 
 
 .. _constants_ANTIALIAS:
@@ -726,6 +730,48 @@ cairo.STATUS
     STATUS_INVALID_MESH_CONSTRUCTION
     STATUS_DEVICE_FINISHED
     STATUS_LAST_STATUS
+
+
+.. _constants_MIME_TYPE:
+
+cairo.MIME_TYPE
+---------------
+
+.. data:: MIME_TYPE_JP2
+    :annotation: = "image/jp2"
+
+    The Joint Photographic Experts Group (JPEG) 2000 image coding standard
+    (ISO/IEC 15444-1).
+
+    .. versionadded:: 1.12.0
+
+.. data:: MIME_TYPE_JPEG
+    :annotation: = "image/jpeg"
+
+    The Joint Photographic Experts Group (JPEG) image coding standard (ISO/IEC
+    10918-1).
+
+    .. versionadded:: 1.12.0
+
+.. data:: MIME_TYPE_PNG
+    :annotation: = "image/png"
+
+    The Portable Network Graphics image file format (ISO/IEC 15948).
+
+    .. versionadded:: 1.12.0
+
+.. data:: MIME_TYPE_URI
+    :annotation: = "text/x-uri"
+
+    URI for an image file (unofficial MIME type).
+
+    .. versionadded:: 1.12.0
+
+.. data:: MIME_TYPE_UNIQUE_ID
+    :annotation: = "application/x-cairo.uuid"
+
+    Unique identifier for a surface (cairo specific MIME type). All surfaces
+    with the same unique identifier will only be embedded once.
 
     .. versionadded:: 1.12.0
 

--- a/docs/reference/surfaces.rst
+++ b/docs/reference/surfaces.rst
@@ -139,6 +139,59 @@ class Surface()
       rendering on them, print surfaces to disable hinting of metrics and so
       forth. The result can then be used with :class:`ScaledFont`.
 
+   .. method:: supports_mime_type(mime_type)
+
+      :param str mime_type: the mime type (:ref:`constants_MIME_TYPE`)
+      :returns: :obj:`True` if surface supports mime_type, :obj:`False`
+        otherwise
+      :rtype: bool
+
+      Return whether surface supports ``mime_type``.
+
+      .. versionadded:: 1.12.0
+
+   .. method:: set_mime_data(mime_type, data)
+
+      :param mime_type: the MIME type of the image data
+        (:ref:`constants_MIME_TYPE`)
+      :type mime_type: str
+      :param data: the image data to attach to the surface
+      :type data: bytes
+
+      Attach an image in the format ``mime_type`` to *Surface*.
+      To remove the data from a surface,
+      call this function with same mime type and :obj:`None` for data.
+
+      The attached image (or filename) data can later be used
+      by backends which support it
+      (currently: PDF, PS, SVG and Win32 Printing surfaces)
+      to emit this data instead of making a snapshot of the surface.
+      This approach tends to be faster and requires less memory and disk space.
+
+      The recognized MIME types are listed under :ref:`constants_MIME_TYPE`.
+
+      See corresponding backend surface docs for details
+      about which MIME types it can handle.
+      Caution: the associated MIME data will be discarded
+      if you draw on the surface afterwards.
+      Use this function with care.
+
+      .. versionadded:: 1.12.0
+
+   .. method:: get_mime_data(mime_type)
+
+      :param mime_type: the MIME type of the image data
+        (:ref:`constants_MIME_TYPE`)
+      :type mime_type: str
+      :returns: :class:`bytes` or :obj:`None`
+
+      Return mime data previously attached to surface
+      with :meth:`set_mime_data` using the specified mime type.
+      If no data has been attached with the given mime type,
+      :obj:`None` is returned.
+
+      .. versionadded:: 1.12.0
+
    .. method:: mark_dirty()
 
       Tells cairo that drawing has been done to *Surface* using means other


### PR DESCRIPTION
Add Surface.set_mime_data(), Surface.get_mime_data(),
Surface.supports_mime_type(), HAS_MIME_SURFACE, MIME_TYPE_*.

set_mime_data() takes a buffer and keeps it alive.
get_mime_data() tries to return the same object.