### PR TITLE
surface: Tie lifetime of surface base objects to the surface, not the…

### DIFF
--- a/cairo/pattern.c
+++ b/cairo/pattern.c
@@ -48,8 +48,6 @@
  *   pattern has an error status.
  * base - the base object used to create the pattern, or NULL.
  *   It is referenced to keep it alive while the cairo_pattern_t is being used.
- *   For PycairoSurfacePattern base should be the PycairoSurface, for other
- #   patterns it should be NULL.
  * Return value: New reference or NULL on failure
  */
 PyObject *
@@ -283,7 +281,7 @@ surface_pattern_new (PyTypeObject *type, PyObject *args, PyObject *kwds) {
 			 &PycairoSurface_Type, &s))
     return NULL;
   return PycairoPattern_FromPattern (
-	     cairo_pattern_create_for_surface (s->surface), (PyObject *)s);
+	     cairo_pattern_create_for_surface (s->surface), NULL);
 }
 
 static PyObject *
@@ -293,14 +291,9 @@ surface_pattern_get_filter (PycairoSurfacePattern *o) {
 
 static PyObject *
 surface_pattern_get_surface (PycairoSurfacePattern *o) {
-  if (o->base != NULL) {
-    /* surface_pattern was created using surface_pattern_new() */
-    return Py_BuildValue("O", o->base);
-  } else {
-    cairo_surface_t *surface;
-    cairo_pattern_get_surface (o->pattern, &surface);
-    return PycairoSurface_FromSurface(cairo_surface_reference (surface), NULL);
-  }
+  cairo_surface_t *surface;
+  RETURN_NULL_IF_CAIRO_ERROR(cairo_pattern_get_surface (o->pattern, &surface));
+  return PycairoSurface_FromSurface(cairo_surface_reference (surface), NULL);
 }
 
 static PyObject *

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,6 +136,22 @@ def test_surface():
         s = cairo.SVGSurface(f, w, h)
 
 
+def test_surface_destroy_before_context():
+    for kind in [cairo.PDFSurface, cairo.PSSurface]:
+        surface = kind(io.BytesIO(), 1, 1)
+        ctx = cairo.Context(surface)
+        del surface
+        ctx.paint()
+
+
+def test_surface_destroy_before_surface_pattern():
+    surface = cairo.PDFSurface(io.BytesIO(), 1, 1)
+    pattern = cairo.SurfacePattern(surface)
+    del surface
+    ctx = cairo.Context(pattern.get_surface())
+    ctx.paint()
+
+
 def test_image_surface_get_data():
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 3, 3)
     ctx = cairo.Context(surface)


### PR DESCRIPTION
… wrapper. Fixes #11

In case the cairo.Surface got deallocated it took the base object with it, but the surface
could still be referenced from some other place like a cairo.Context/SurfacePattern.
In case the referencing object would then try to use the surface things crash.

Tie the lifetime to the actual object instead using the user_data API.