### PR TITLE
PDFSurface: Add version API

### DIFF
--- a/cairo/cairomodule.c
+++ b/cairo/cairomodule.c
@@ -39,6 +39,10 @@
 #ifdef CAIRO_HAS_PS_SURFACE
 #  include <cairo-ps.h>
 #endif
+/* to read CAIRO_PDF_VERSION_* constants */
+#ifdef CAIRO_HAS_PDF_SURFACE
+#  include <cairo-pdf.h>
+#endif
 
 /* for XCB api */
 #if defined(CAIRO_HAS_XCB_SURFACE) && defined(HAVE_XPYB)
@@ -625,6 +629,11 @@ PYCAIRO_MOD_INIT(_cairo)
   CONSTANT(PATH_LINE_TO);
   CONSTANT(PATH_CURVE_TO);
   CONSTANT(PATH_CLOSE_PATH);
+
+#ifdef CAIRO_HAS_PDF_SURFACE
+  CONSTANT(PDF_VERSION_1_4);
+  CONSTANT(PDF_VERSION_1_5);
+#endif
 
   CONSTANT(REGION_OVERLAP_IN);
   CONSTANT(REGION_OVERLAP_OUT);

--- a/docs/reference/constants.rst
+++ b/docs/reference/constants.rst
@@ -639,6 +639,28 @@ enabled.
    The language level 3 of the PostScript specification.
 
 
+.. _constants_PDF_VERSION:
+
+cairo.PDF_VERSION
+-----------------
+
+These constants are used to describe the version number of the PDF
+specification that a generated PDF file will conform to.
+
+.. data:: PDF_VERSION_1_4
+
+    The version 1.4 of the PDF specification.
+
+    .. versionadded:: 1.12.0
+
+
+.. data:: PDF_VERSION_1_5
+
+    The version 1.5 of the PDF specification.
+
+    .. versionadded:: 1.12.0
+
+
 .. _constants_SUBPIXEL_ORDER:
 
 cairo.SUBPIXEL_ORDER

--- a/docs/reference/surfaces.rst
+++ b/docs/reference/surfaces.rst
@@ -473,6 +473,43 @@ multi-page vector surface backend.
 
       .. versionadded:: 1.2
 
+   .. method:: restrict_to_version(version)
+
+      :param version: PDF version
+      :type version: :ref:`constants_PDF_VERSION`
+
+      Restricts the generated PDF file to version . See :meth:`get_versions`
+      for a list of available version values that can be used here.
+
+      This function should only be called before any drawing operations have
+      been performed on the given surface. The simplest way to do this is to
+      call this function immediately after creating the surface.
+
+      .. versionadded:: 1.12.0
+
+   .. staticmethod:: get_versions()
+
+      :returns: supported version list
+      :rtype: list
+
+      Retrieve the list of supported versions. See
+      :meth:`restrict_to_version`.
+
+      .. versionadded:: 1.12.0
+
+   .. staticmethod:: version_to_string(version)
+
+      :param version: PDF version
+      :type version: :ref:`constants_PDF_VERSION`
+      :returns: the string associated to the given version
+      :rtype: str
+      :raises ValueError: if version isn't valid
+
+      Get the string representation of the given version id. See
+      :meth:`get_versions` for a way to get the list of valid version ids.
+
+      .. versionadded:: 1.12.0
+
 
 class PSSurface(:class:`Surface`)
 =================================

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,6 +46,27 @@ def test_surface_create_similar_image():
     assert image.get_height() == 42
 
 
+def test_pdf_get_versions():
+    versions = cairo.PDFSurface.get_versions()
+    assert isinstance(versions, list)
+    assert all(isinstance(v, int) for v in versions)
+
+
+def test_pdf_surface_restrict_to_version():
+    surface = cairo.PDFSurface(None, 10, 10)
+    surface.restrict_to_version(cairo.PDF_VERSION_1_4)
+    surface.finish()
+    with pytest.raises(cairo.Error):
+        surface.restrict_to_version(cairo.PDF_VERSION_1_5)
+
+
+def test_pdf_version_to_string():
+    ver = cairo.PDFSurface.version_to_string(cairo.PDF_VERSION_1_4)
+    assert ver and isinstance(ver, str)
+    with pytest.raises(ValueError):
+        cairo.PDFSurface.version_to_string(-1)
+
+
 def test_error_context():
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 100, 100)
     ctx = cairo.Context(surface)


### PR DESCRIPTION
This adds:

* cairo.PDF_VERSION_1_4 and cairo.PDF_VERSION_1_5
* cairo.PDFSurface.restrict_to_version()
* cairo.PDFSurface.get_versions()
* cairo.PDFSurface.version_to_string()