### PR TITLE
setup.py: Alwasy use -Wno-strict-aliasing under Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
       dist: trusty
       language: python
       python: "2.7"
-      env: CFLAGS="-std=c90 -pedantic -Wno-long-long -Werror -Wno-strict-aliasing"
+      env: CFLAGS="-std=c90 -pedantic -Wno-long-long -Werror"
     - os: linux
       dist: trusty
       language: python

--- a/setup.py
+++ b/setup.py
@@ -207,6 +207,12 @@ class install_data(du_install_data):
 
 def main():
 
+    extra_compile_args = []
+    if sys.version_info[0] == 2:
+        # Some python setups don't pass -fno-strict-aliasing, while MACROS like
+        # Py_RETURN_TRUE require it. This makes sure these cases are ignores.
+        extra_compile_args.append("-Wno-strict-aliasing")
+
     cairo_ext = Extension(
         name='cairo._cairo',
         sources=[
@@ -223,6 +229,7 @@ def main():
         include_dirs=pkg_config_parse('--cflags-only-I', 'cairo'),
         library_dirs=pkg_config_parse('--libs-only-L', 'cairo'),
         libraries=pkg_config_parse('--libs-only-l', 'cairo'),
+        extra_compile_args=extra_compile_args,
     )
 
     setup(


### PR DESCRIPTION
Some Python 2 envs enable strict aliasing for build_ext. While we could fix
most cases, internal macros like Py_RETURN_TRUE warn too. Just disable the
warnings for Python 2.