### PR TITLE
Fix leak when using ImageSurface.get_data() with Python 3. Fixes #41

### DIFF
--- a/cairo/bufferproxy.c
+++ b/cairo/bufferproxy.c
@@ -1,0 +1,135 @@
+/* -*- mode: C; c-basic-offset: 2 -*-
+ *
+ * Pycairo - Python bindings for cairo
+ *
+ * Copyright © 2017 Christoph Reiter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it either under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation
+ * (the "LGPL") or, at your option, under the terms of the Mozilla
+ * Public License Version 1.1 (the "MPL"). If you do not alter this
+ * notice, a recipient may use your version of this file under either
+ * the MPL or the LGPL.
+ *
+ * You should have received a copy of the LGPL along with this library
+ * in the file COPYING-LGPL-2.1; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * You should have received a copy of the MPL along with this library
+ * in the file COPYING-MPL-1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY
+ * OF ANY KIND, either express or implied. See the LGPL or the MPL for
+ * the specific language governing rights and limitations.
+ */
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include "config.h"
+#include "private.h"
+
+#if PY_MAJOR_VERSION >= 3
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *exporter;
+    void *buf;
+    Py_ssize_t len;
+} Pycairo_BufferProxy;
+
+static PyTypeObject Pycairo_BufferProxyType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "cairo._BufferProxy",
+    sizeof(Pycairo_BufferProxy),
+};
+
+static int
+buffer_proxy_getbuffer(PyObject *exporter, Py_buffer *view, int flags)
+{
+    Pycairo_BufferProxy *self = (Pycairo_BufferProxy *)exporter;
+
+    return PyBuffer_FillInfo (view, exporter, self->buf, self->len, 0, 0);
+}
+
+static PyBufferProcs Pycairo_BufferProxy_as_buffer = {
+    (getbufferproc)buffer_proxy_getbuffer,
+    (releasebufferproc)0,
+};
+
+PyObject *
+buffer_proxy_create_view(PyObject *exporter, void *buf, Py_ssize_t len) {
+    PyObject *memoryview;
+    PyObject *obj;
+    Pycairo_BufferProxy *self;
+
+    obj = (PyObject *)PyObject_GC_New(Pycairo_BufferProxy,
+                                      &Pycairo_BufferProxyType);
+    if (obj == NULL)
+        return NULL;
+
+    self = (Pycairo_BufferProxy *)obj;
+    Py_INCREF(exporter);
+    self->exporter = exporter;
+    self->buf = buf;
+    self->len = len;
+    PyObject_GC_Track(obj);
+
+    memoryview = PyMemoryView_FromObject (obj);
+    Py_DECREF(obj);
+
+    return memoryview;
+}
+
+static int
+buffer_proxy_traverse(PyObject* obj, visitproc visit, void *arg)
+{
+    Pycairo_BufferProxy *self = (Pycairo_BufferProxy *)obj;
+
+    Py_VISIT(self->exporter);
+    return 0;
+}
+
+static int
+buffer_proxy_clear(PyObject *obj)
+{
+    Pycairo_BufferProxy *self = (Pycairo_BufferProxy *)obj;
+
+    Py_CLEAR(self->exporter);
+    return 0;
+}
+
+static void
+buffer_proxy_dealloc(PyObject* obj)
+{
+    Pycairo_BufferProxy *self = (Pycairo_BufferProxy *)obj;
+
+    PyObject_GC_UnTrack(obj);
+
+    self->buf = NULL;
+    self->len = 0;
+    Py_DECREF(self->exporter);
+
+    Py_TYPE(obj)->tp_free(obj);
+}
+#endif
+
+int
+init_buffer_proxy (void) {
+#if PY_MAJOR_VERSION >= 3
+    Pycairo_BufferProxyType.tp_as_buffer = &Pycairo_BufferProxy_as_buffer;
+    Pycairo_BufferProxyType.tp_dealloc = &buffer_proxy_dealloc;
+    Pycairo_BufferProxyType.tp_traverse = &buffer_proxy_traverse;
+    Pycairo_BufferProxyType.tp_clear = &buffer_proxy_clear;
+    Pycairo_BufferProxyType.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC;
+
+    if (PyType_Ready(&Pycairo_BufferProxyType) < 0)
+        return -1;
+#endif
+    return 0;
+}

--- a/cairo/cairomodule.c
+++ b/cairo/cairomodule.c
@@ -315,6 +315,9 @@ PYCAIRO_MOD_INIT(_cairo)
   if (m == NULL)
     return PYCAIRO_MOD_ERROR_VAL;
 
+  if(init_buffer_proxy() < 0)
+    return PYCAIRO_MOD_ERROR_VAL;
+
   if(init_enums(m) < 0)
     return PYCAIRO_MOD_ERROR_VAL;
 

--- a/cairo/private.h
+++ b/cairo/private.h
@@ -193,6 +193,10 @@ int Pycairo_Check_Status (cairo_status_t status);
 
 PyObject *error_get_type(void);
 
+int init_buffer_proxy(void);
+
+PyObject *buffer_proxy_create_view(PyObject *exporter, void *buf, Py_ssize_t len);
+
 /* int enums */
 
 int init_enums(PyObject *module);

--- a/cairo/surface.c
+++ b/cairo/surface.c
@@ -765,7 +765,6 @@ image_surface_format_stride_for_width (PyObject *self, PyObject *args) {
 static PyObject *
 image_surface_get_data (PycairoImageSurface *o) {
 #if PY_MAJOR_VERSION >= 3
-  Py_buffer view;
   cairo_surface_t *surface;
   int height, stride;
   unsigned char * buffer;
@@ -777,10 +776,8 @@ image_surface_get_data (PycairoImageSurface *o) {
   }
   height = cairo_image_surface_get_height (surface);
   stride = cairo_image_surface_get_stride (surface);
-  if (PyBuffer_FillInfo (&view, (PyObject *)o, buffer, height * stride, 0, 0) < 0)
-    return NULL;
 
-  return PyMemoryView_FromBuffer (&view);
+  return buffer_proxy_create_view((PyObject *)o, buffer, height * stride);
 #else
   return PyBuffer_FromReadWriteObject((PyObject *)o, 0, Py_END_OF_BUFFER);
 #endif

--- a/setup.py
+++ b/setup.py
@@ -230,6 +230,7 @@ def main():
     cairo_ext = Extension(
         name='cairo._cairo',
         sources=[
+            'cairo/bufferproxy.c',
             'cairo/error.c',
             'cairo/cairomodule.c',
             'cairo/context.c',

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -2,12 +2,22 @@
 
 import io
 import os
+import sys
 import array
 import tempfile
 import struct
 
 import cairo
 import pytest
+
+
+def test_image_surface_get_data_refcount():
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
+    assert sys.getrefcount(surface) == 2
+    d = surface.get_data()
+    assert sys.getrefcount(surface) == 3
+    del d
+    assert sys.getrefcount(surface) == 2
 
 
 def test_surface_get_content():


### PR DESCRIPTION
Turns out the buffer/memoryview API can only be used in implementations
of the buffer protocol of some object and the current approach
worked by accident and for some unknown reason leaked the exporter as
well.

This creates a new Python class implementing the buffer interface,
which takes the buffer information and is only used to keep the
image surface alive and to hand out memory views.

In case the last view dies, the proxy will die and unref the image
surface.