### PR TITLE
Add Surface.map_to_image() and Surface.unmap_image(). Fixes #51

### DIFF
--- a/cairo/cairomodule.c
+++ b/cairo/cairomodule.c
@@ -287,6 +287,8 @@ PYCAIRO_MOD_INIT(_cairo)
 #ifdef CAIRO_HAS_IMAGE_SURFACE
   if (PyType_Ready(&PycairoImageSurface_Type) < 0)
     return PYCAIRO_MOD_ERROR_VAL;
+  if (PyType_Ready(&PycairoMappedImageSurface_Type) < 0)
+    return PYCAIRO_MOD_ERROR_VAL;
 #endif
 #ifdef CAIRO_HAS_PDF_SURFACE
   if (PyType_Ready(&PycairoPDFSurface_Type) < 0)

--- a/cairo/private.h
+++ b/cairo/private.h
@@ -94,6 +94,7 @@ PyObject *PycairoScaledFont_FromScaledFont (cairo_scaled_font_t *scaled_font);
 
 extern PyTypeObject PycairoSurface_Type;
 extern PyTypeObject PycairoImageSurface_Type;
+extern PyTypeObject PycairoMappedImageSurface_Type;
 
 typedef struct {
     PyObject_HEAD

--- a/docs/reference/surfaces.rst
+++ b/docs/reference/surfaces.rst
@@ -385,6 +385,44 @@ class Surface()
 
       .. versionadded:: 1.14.0
 
+   .. method:: map_to_image(extents)
+
+      :param RectangleInt extents: limit the extraction to an rectangular
+         region or :obj:`None` for the whole surface
+
+      :returns: newly allocated image surface
+      :rtype: ImageSurface
+      :raises Error:
+
+      Returns an image surface that is the most efficient mechanism for
+      modifying the backing store of the target surface.
+
+      Note, the use of the original surface as a target or source whilst it is
+      mapped is undefined. The result of mapping the surface multiple times is
+      undefined. Calling :meth:`Surface.finish` on the resulting image surface
+      results in undefined behavior. Changing the device transform of the
+      image surface or of surface before the image surface is unmapped results
+      in undefined behavior.
+
+      The caller must use :meth:`Surface.unmap_image` to destroy this image
+      surface.
+
+      .. versionadded:: 1.15.0
+
+   .. method:: unmap_image(image)
+
+      :param ImageSurface image: the currently mapped image
+
+      Unmaps the image surface as returned from :meth:`Surface.map_to_image`.
+
+      The content of the image will be uploaded to the target surface.
+      Afterwards, the image is destroyed.
+
+      Using an image surface which wasn't returned by
+      :meth:`Surface.map_to_image` results in undefined behavior.
+
+      .. versionadded:: 1.15.0
+
 
 class ImageSurface(:class:`Surface`)
 ====================================


### PR DESCRIPTION
This keeps the same API as cairo but adds some additional checks
to prevent crashes. Those cases still are undefined but at least
you get some error messages.

* It adds a new ImageSurface subtype so we can do some type checking.
* It swaps the underlying image surface to a dummy finished one
  when it gets unmapped so that operations after unmap
  on the wrapper don't crash.
* It checks if the source surface is correct when unmapping.