### PR TITLE
cairo/context.c: preserve signedness in cairo_{get,set}_operator

### DIFF
--- a/cairo/context.c
+++ b/cairo/context.c
@@ -416,7 +416,8 @@ pycairo_get_miter_limit (PycairoContext *o) {
 
 static PyObject *
 pycairo_get_operator (PycairoContext *o) {
-  RETURN_INT_ENUM(Operator, cairo_get_operator (o->ctx));
+  /* See NOTE ['cairo_operator_t' underlying type] */
+  RETURN_INT_ENUM(Operator, (int)cairo_get_operator (o->ctx));
 }
 
 static PyObject *
@@ -954,6 +955,16 @@ static PyObject *
 pycairo_set_operator(PycairoContext *o, PyObject *args) {
   cairo_operator_t op;
 
+  /* NOTE ['cairo_operator_t' underlying type]
+   *
+   * Internally 'cairo_operator_t' has 'enum' type
+   * happens to be backed by 'unsigned int' as it does
+   * not contain negative or big enough values.
+   * But here we read it as 'signed int' variable with
+   * PyArg_ParseTuple.
+   * pycairo_get_operator will cast 'unsigned int' back
+   * to 'signed int'.
+   */
   if (!PyArg_ParseTuple(args, "i:Context.set_operator", &op))
     return NULL;
 


### PR DESCRIPTION
I've noticed the failure [1] on big-endian powerpc64 and
little-endian amd64 using python2.

The failure is simple here:
    E       assert 4294967295 == -1
means the ollowing:
  cairo_set_operator(-1)
  cairo_get_operator() = 4294967295

which is the same 'int' value in signed and unsigned forms.
The cast from 'signed' to 'unsigned' happens in
    cairo_set_operator(-1)
in PyArg_ParseTuple (as python2 has no unsigned integral types).

The change amends 'cairo_get_operator' to account for
signedness flip and makes tests pass on powerpc64.

[1]:
```
================ FAILURES =============
______ test_context_get_set_operator __

    @given(integers())
>   def test_context_get_set_operator(value):

tests/test_hypothesis.py:183:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/lib64/python2.7/site-packages/hypothesis/core.py:524: in wrapped_test
    print_example=True, is_final=True
/usr/lib64/python2.7/site-packages/hypothesis/executors.py:58: in default_new_style_executor
    return function(data)
/usr/lib64/python2.7/site-packages/hypothesis/core.py:111: in run
    return test(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

value = -1

    @given(integers())
    def test_context_get_set_operator(value):
        try:
            op = cairo.Operator(value)
        except OverflowError:
            return

        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
        context = cairo.Context(surface)
        try:
            context.set_operator(op)
        except OverflowError:
            return
>       assert context.get_operator() == op
E       assert 4294967295 == -1
E        +  where 4294967295 = <built-in method get_operator of cairo.Context object at 0x3fff88a9d0d0>()
E        +    where <built-in method get_operator of cairo.Context object at 0x3fff88a9d0d0> = <cairo.Context object at 0x3fff88a9d0d0>.get_operator

tests/test_hypothesis.py:195: AssertionError
---------------- Hypothesis -----------
Falsifying example: test_context_get_set_operator(value=-1)
================ 1 failed, 258 passed, 1 skipped in 9.76 seconds
```

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>