### PR TITLE
Make cairo.Surface and cairo.Device context managers. Fixes #103

### DIFF
--- a/cairo/device.c
+++ b/cairo/device.c
@@ -72,7 +72,23 @@ device_release (PycairoDevice *obj) {
     Py_RETURN_NONE;
 }
 
+static PyObject *
+device_ctx_enter (PyObject *obj) {
+    Py_INCREF (obj);
+    return obj;
+}
+
+static PyObject *
+device_ctx_exit (PycairoDevice *obj, PyObject *args) {
+    Py_BEGIN_ALLOW_THREADS;
+    cairo_device_finish (obj->device);
+    Py_END_ALLOW_THREADS;
+    Py_RETURN_NONE;
+}
+
 static PyMethodDef device_methods[] = {
+    {"__enter__",      (PyCFunction)device_ctx_enter,          METH_NOARGS},
+    {"__exit__",       (PyCFunction)device_ctx_exit,           METH_VARARGS},
     {"finish",         (PyCFunction)device_finish,             METH_NOARGS},
     {"flush",          (PyCFunction)device_flush,              METH_NOARGS},
     {"acquire",        (PyCFunction)device_acquire,            METH_NOARGS},

--- a/cairo/surface.c
+++ b/cairo/surface.c
@@ -655,6 +655,20 @@ surface_unmap_image (PycairoSurface *self, PyObject *args) {
 
 #endif /* CAIRO_HAS_IMAGE_SURFACE */
 
+static PyObject *
+surface_ctx_enter (PyObject *obj) {
+  Py_INCREF (obj);
+  return obj;
+}
+
+static PyObject *
+surface_ctx_exit (PycairoSurface *obj, PyObject *args) {
+  Py_BEGIN_ALLOW_THREADS;
+  cairo_surface_finish (obj->surface);
+  Py_END_ALLOW_THREADS;
+  Py_RETURN_NONE;
+}
+
 static PyMethodDef surface_methods[] = {
   /* methods never exposed in a language binding:
    * cairo_surface_destroy()
@@ -663,6 +677,8 @@ static PyMethodDef surface_methods[] = {
    * cairo_surface_reference()
    * cairo_surface_set_user_data()
    */
+  {"__enter__",      (PyCFunction)surface_ctx_enter,          METH_NOARGS},
+  {"__exit__",       (PyCFunction)surface_ctx_exit,           METH_VARARGS},
   {"copy_page",      (PyCFunction)surface_copy_page,          METH_NOARGS},
   {"create_similar", (PyCFunction)surface_create_similar,     METH_VARARGS},
   {"create_similar_image", (PyCFunction)surface_create_similar_image,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -8,6 +8,17 @@ import cairo
 import pytest
 
 
+def test_context_manager():
+    f = io.BytesIO()
+    with cairo.ScriptDevice(f) as dev:
+        dev.acquire()
+        dev.release()
+
+    with pytest.raises(cairo.Error) as excinfo:
+        dev.acquire()
+    assert excinfo.value.status == cairo.Status.DEVICE_FINISHED
+
+
 def test_cmp_hash():
     f = io.BytesIO()
     dev = cairo.ScriptDevice(f)

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -13,6 +13,14 @@ import cairo
 import pytest
 
 
+def test_context_manager():
+    with cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10) as surface:
+        surface.show_page()
+    with pytest.raises(cairo.Error) as excinfo:
+        surface.show_page()
+    assert excinfo.value.status == cairo.Status.SURFACE_FINISHED
+
+
 def test_surface_cmp_hash():
     main = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     ctx = cairo.Context(main)


### PR DESCRIPTION
calls finish() in \_\_exit\_\_()