### PR TITLE
c-api: Make it possible to use the C API with Python 3 outside of the CU doing the import. Fixes #110

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,6 @@ include MANIFEST.in
 include setup.cfg
 recursive-include docs *.py Makefile *.rst *.css *.svg
 prune docs/_build
-recursive-include tests *.py README *.c
+recursive-include tests *.py README *.c *.h
 recursive-include examples *.py README
 include cairo/*.h

--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,8 @@ Since version 1.11.0 Pycairo uses `Semantic Versioning
   managers. :bug:`103`
 * Fix a leak when a cairo error was raised.
 * Fix a leak when a mapped surface was GCed instead of unmapped.
+* Make it possible to use the C API with Python 3 outside of the compilation
+  unit doing the import by defining ``PYCAIRO_NO_IMPORT``. :bug:`110`
 
 
 .. _v1.16.3:

--- a/cairo/pycairo.h
+++ b/cairo/pycairo.h
@@ -249,11 +249,17 @@ typedef struct {
 
 #else
 
+#ifdef PYCAIRO_NO_IMPORT
+
+extern Pycairo_CAPI_t *Pycairo_CAPI;
+
+#else
+
 /* To access the Pycairo C API, the client module should call 'import_cairo()'
  * from the init<module> function, and check the return value, < 0 means the
  * import failed.
  */
-static Pycairo_CAPI_t *Pycairo_CAPI;
+Pycairo_CAPI_t *Pycairo_CAPI;
 
 /* Return -1 on error, 0 on success.
  * PyCapsule_Import will set an exception if there's an error.
@@ -264,6 +270,8 @@ import_cairo(void)
   Pycairo_CAPI = (Pycairo_CAPI_t*) PyCapsule_Import("cairo.CAPI", 0);
   return (Pycairo_CAPI != 0) ? 0 : -1;
 }
+
+#endif
 
 #endif
 

--- a/docs/pycairo_c_api.rst
+++ b/docs/pycairo_c_api.rst
@@ -59,11 +59,18 @@ Edit the client module file to add the following lines::
   #include "pycairo.h"
 
   /* define a variable for the C API */
-  static Pycairo_CAPI_t *Pycairo_CAPI;
+  Pycairo_CAPI_t *Pycairo_CAPI;
 
   /* import pycairo - add to the init<module> function */
   Pycairo_IMPORT;
 
+In case you want to use the API from another compilation unit::
+
+  #include <pycairo.h>
+
+  extern Pycairo_CAPI_t *Pycairo_CAPI;
+
+  ...
 
 To access the Pycairo C API under Python 3
 ==========================================
@@ -85,6 +92,17 @@ Example showing how to import the pycairo API::
     /* additional initialization can happen here */
     return m;
   }
+
+In case you want to use the API from another compilation unit::
+
+  #define PYCAIRO_NO_IMPORT
+  #include <py3cairo.h>
+
+  ...
+
+.. versionadded:: 1.17.0
+
+    The ``PYCAIRO_NO_IMPORT`` macro is used since 1.17.0
 
 
 Misc Functions

--- a/setup.py
+++ b/setup.py
@@ -197,12 +197,15 @@ class build_tests(Command):
             name='tests.cmod',
             sources=[
                 os.path.join(tests_dir, "cmodule.c"),
+                os.path.join(tests_dir, "cmodulelib.c"),
             ],
             include_dirs=[
                 tests_dir,
                 cairo.get_include(),
             ],
             depends=[
+                os.path.join(tests_dir, "cmodulelib.h"),
+                os.path.join(cairo.get_include(), "pycairo.h"),
             ],
             define_macros=[("PY_SSIZE_T_CLEAN", None)],
         )

--- a/tests/cmodule/cmodule.c
+++ b/tests/cmodule/cmodule.c
@@ -1,18 +1,7 @@
 #include <Python.h>
 /* not pycairo3.h because we use the one from the source directory */
 #include <pycairo.h>
-
-static Pycairo_CAPI_t *Pycairo_CAPI;
-
-static PyObject *
-create_image_surface (PyObject *self, PyObject *args)
-{
-    cairo_surface_t *surface;
-
-    surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, 10, 10);
-
-    return PycairoSurface_FromSurface (surface, NULL);
-}
+#include "cmodulelib.h"
 
 static PyMethodDef CModMethods[] = {
     {"create_image_surface", create_image_surface, METH_NOARGS, NULL},
@@ -20,6 +9,8 @@ static PyMethodDef CModMethods[] = {
 };
 
 #if PY_MAJOR_VERSION < 3
+
+Pycairo_CAPI_t *Pycairo_CAPI;
 
 PyMODINIT_FUNC
 initcmod (void)

--- a/tests/cmodule/cmodulelib.c
+++ b/tests/cmodule/cmodulelib.c
@@ -1,0 +1,18 @@
+#include <Python.h>
+#define PYCAIRO_NO_IMPORT
+#include <pycairo.h>
+#include "cmodulelib.h"
+
+#if PY_MAJOR_VERSION < 3
+extern Pycairo_CAPI_t *Pycairo_CAPI;
+#endif
+
+PyObject *
+create_image_surface (PyObject *self, PyObject *args)
+{
+    cairo_surface_t *surface;
+
+    surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, 10, 10);
+
+    return PycairoSurface_FromSurface (surface, NULL);
+}

--- a/tests/cmodule/cmodulelib.h
+++ b/tests/cmodule/cmodulelib.h
@@ -1,0 +1,6 @@
+#ifndef _PYCAIRO_CMODULELIB_H_
+#define _PYCAIRO_CMODULELIB_H_
+
+PyObject *create_image_surface (PyObject *self, PyObject *args);
+
+#endif


### PR DESCRIPTION
In case PYCAIRO_NO_IMPORT is defined we declare the api struct as extern and hide the
import function. Also don't make the API struct static so we can access it from outside.