### PR TITLE
meson builds: Improve support for Visual Studio builds

### DIFF
--- a/cairo/meson.build
+++ b/cairo/meson.build
@@ -34,7 +34,13 @@ endforeach
 
 python_dep = python.dependency()
 
-cairo_dep = dependency('cairo', version: cair_version_req)
+cairo_dep = dependency('cairo', version: cair_version_req, required: cc.get_id() != 'msvc')
+
+if cc.get_id() == 'msvc' and not cairo_dep.found()
+  if cc.has_header('cairo.h')
+    cairo_dep = cc.find_library('cairo')
+  endif
+endif
 
 python.install_sources(python_sources,
   pure : false,

--- a/cairo/private.h
+++ b/cairo/private.h
@@ -313,4 +313,23 @@ DECL_ENUM(PSLevel)
 DECL_ENUM(ScriptMode)
 #endif
 
+/* Use to disable deprecation warnings temporarily */
+#ifdef _MSC_VER
+# define PYCAIRO_BEGIN_IGNORE_DEPRECATED \
+  __pragma (warning (push)) \
+  __pragma (warning (disable : 4996))
+
+# define PYCAIRO_END_IGNORE_DEPRECATED \
+  __pragma (warning (pop))
+
+#else
+
+# define PYCAIRO_BEGIN_IGNORE_DEPRECATED \
+  _Pragma ("GCC diagnostic push") \
+  _Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+
+# define PYCAIRO_END_IGNORE_DEPRECATED \
+  _Pragma ("GCC diagnostic pop")
+#endif
+
 #endif /* _PYCAIRO_PRIVATE_H_ */

--- a/cairo/surface.c
+++ b/cairo/surface.c
@@ -475,10 +475,9 @@ surface_set_mime_data (PycairoSurface *o, PyObject *args) {
     Py_RETURN_NONE;
   }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+PYCAIRO_BEGIN_IGNORE_DEPRECATED
   res = PyObject_AsReadBuffer (obj, (const void **)&buffer, &buffer_len);
-#pragma GCC diagnostic pop
+PYCAIRO_END_IGNORE_DEPRECATED
   if (res == -1)
     return NULL;
 
@@ -821,10 +820,9 @@ image_surface_create_for_data (PyTypeObject *type, PyObject *args) {
 
   format = (cairo_format_t)format_arg;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+PYCAIRO_BEGIN_IGNORE_DEPRECATED
   res = PyObject_AsWriteBuffer (obj, (void **)&buffer, &buffer_len);
-#pragma GCC diagnostic pop
+PYCAIRO_END_IGNORE_DEPRECATED
   if (res == -1)
     return NULL;
 

--- a/meson.build
+++ b/meson.build
@@ -19,50 +19,90 @@ configure_file(
   configuration: configuration_data(),
 )
 
-main_c_args = [
-  '-Wall',
-  '-Warray-bounds',
-  '-Wcast-align',
-  '-Wconversion',
-  '-Wdeclaration-after-statement',
-  '-Wextra',
-  '-Wformat=2',
-  '-Wformat-nonliteral',
-  '-Wformat-security',
-  '-Wimplicit-function-declaration',
-  '-Winit-self',
-  '-Winline',
-  '-Wmissing-format-attribute',
-  '-Wmissing-noreturn',
-  '-Wnested-externs',
-  '-Wold-style-definition',
-  '-Wpacked',
-  '-Wpointer-arith',
-  '-Wreturn-type',
-  '-Wshadow',
-  '-Wsign-compare',
-  '-Wstrict-aliasing',
-  '-Wundef',
-  '-Wunused-but-set-variable',
-]
+cc = meson.get_compiler('c')
 
-main_c_args += [
-  '-Wno-missing-field-initializers',
-  '-Wno-unused-parameter',
-]
-
-main_c_args += [
-  '-fno-strict-aliasing',
-  '-fvisibility=hidden',
-]
-
-if not ['3.3', '3.4'].contains(python.language_version())
+main_c_args = []
+if cc.get_id() == 'msvc'
+# Adapted from msvc_recommended_pragmas.h, since we don't depend on GLib here
+# Warnings that we want to look out for
   main_c_args += [
-    '-Wswitch-default',
+    '-we4002', # too many actual parameters for macro
+    '-we4003', # not enough actual parameters for macro
+    '-w14010', # single-line comment contains line-continuation character
+    '-we4013', # 'function' undefined; assuming extern returning int
+    '-w14016', # no function return type; using int as default
+    '-we4020', # too many actual parameters
+    '-we4021', # too few actual parameters
+    '-we4027', # function declared without formal parameter list
+    '-we4029', # declared formal parameter list different from definition
+    '-we4033', # 'function' must return a value
+    '-we4035', # 'function' : no return value
+    '-we4045', # array bounds overflow
+    '-we4047', # different levels of indirection
+    '-we4049', # terminating line number emission
+    '-we4053', # An expression of type void was used as an operand
+    '-we4071', # no function prototype given
+    '-we4150',
+    '-we4819', # The file contains a character that cannot be represented in the current code page
   ]
+
+# Silence warnings for stuff that should not really raise concern
+  main_c_args += [
+    '-wd4101', # unreferenced local variable
+    '-wd4244', # No possible loss of data warnings
+    '-wd4305', # No truncation from int to char warnings
+  ]
+
+# Silence warnings for using non-MS CRT stuff
+  main_c_args += [
+    '-D_CRT_SECURE_NO_WARNINGS',
+    '-D_CRT_NONSTDC_NO_WARNINGS'
+  ]
+else
+  main_c_args += [
+    '-Wall',
+    '-Warray-bounds',
+    '-Wcast-align',
+    '-Wconversion',
+    '-Wdeclaration-after-statement',
+    '-Wextra',
+    '-Wformat=2',
+    '-Wformat-nonliteral',
+    '-Wformat-security',
+    '-Wimplicit-function-declaration',
+    '-Winit-self',
+    '-Winline',
+    '-Wmissing-format-attribute',
+    '-Wmissing-noreturn',
+    '-Wnested-externs',
+    '-Wold-style-definition',
+    '-Wpacked',
+    '-Wpointer-arith',
+    '-Wreturn-type',
+    '-Wshadow',
+    '-Wsign-compare',
+    '-Wstrict-aliasing',
+    '-Wundef',
+    '-Wunused-but-set-variable',
+  ]
+
+  main_c_args += [
+    '-Wno-missing-field-initializers',
+    '-Wno-unused-parameter',
+  ]
+
+  main_c_args += [
+    '-fno-strict-aliasing',
+    '-fvisibility=hidden',
+  ]
+
+  if not ['3.3', '3.4'].contains(python.language_version())
+    main_c_args += [
+      '-Wswitch-default',
+    ]
+  endif
 endif
 
-cc = meson.get_compiler('c')
 main_c_args = cc.get_supported_arguments(main_c_args)
 
 pycairo_version = meson.project_version()


### PR DESCRIPTION
Hi,

This PR is opened to improve the support for Visual Studio builds done using Meson, which basically does the following for Visual Studio builds:

-Check for Cairo headers and libraries manually if the pkg-config file(s) for Cairo could not be found.
-Check for the warnings that we want to look out for and those we want to ignore, and include them as CFlags in MSVC-style.

With blessings, thank you!