### PR TITLE
meson: fix configure error with meson 0.50 re absolute paths. Fixes #144

### DIFF
--- a/cairo/meson.build
+++ b/cairo/meson.build
@@ -61,7 +61,7 @@ header_file = configure_file(
 
 install_headers(
   [header_file],
-  subdir: join_paths(python.get_install_dir(), 'cairo', 'include'),
+  install_dir: join_paths(python.get_install_dir(), 'cairo', 'include'),
 )
 install_headers([header_file], subdir: 'pycairo')
 


### PR DESCRIPTION
The newest meson version has started to fail:
meson.build:62:0: ERROR: Subdir keyword must not be an absolute path.

Fix by using install_dir instead of subdir.