### PR TITLE
Use pkgutil to extend the search path for out-of-tree builds

### DIFF
--- a/cairo/__init__.py
+++ b/cairo/__init__.py
@@ -1,5 +1,13 @@
-from ._cairo import *  # noqa: F401,F403
-
+# support overrides in different directories than our module
+# so we can use _cairo from an external build dir
+try:
+    from ._cairo import *  # noqa: F401,F403
+except ImportError:
+    # If import fails, try an extended path search,
+    # to work with uninstalled out-of-tree build setups
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)
+    from ._cairo import *  # noqa: F401,F403
 
 def get_include():
     """Returns a path to the directory containing the C header files"""


### PR DESCRIPTION
Using pkgutil to extend __path__ allows pycairo to find the
_cairo extension if it's build out-of-tree, which in turn
lets it be used uninstalled for easier development.

This is useful for the GStreamer gst-build developer shell
environment for example.

The technique is taken from pygobject's gi module
(see https://bugzilla.gnome.org/show_bug.cgi?id=680913)