### PR TITLE
Add machine-readable license statement

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -15,3 +15,5 @@ conditions of either license:
 
 Please see each file in the implementation for Copyright and licensing
 information.
+
+SPDX-License-Identifier: LGPL-2.1-only OR MPL-1.1


### PR DESCRIPTION
Hi!

In the process of packaging this library, I got confused on the licensing here. The docs are *good,* they say up front:

> Pycairo, including this documentation, is licensed under the LGPLv2.1 as well as the MPLv1.1.

... but sadly, it's not good enough. How does one interpret "as well", does it stand for "both", does it stand for "either" ? Is LGPLv2.1 assumed with the "or later" clause, or is there a choice to stick with version 2.1 *only* of the LGPL ?

To disambiguate this once-and-for-all, I'm using the [SPDX standard](https://spdx.org/ids), please check out their spec if it's something new. Also, let me know if I guessed the expression incorrectly.

**TL;DR:** This line adds a standard machine-readable license tag, so that your license choice won't get lost or misinterpreted when scanning hundreds of packages using automated tools. Please merge.