### PR TITLE
Feature/azure fixes

### DIFF
--- a/.azure-pipelines/msys2.sh
+++ b/.azure-pipelines/msys2.sh
@@ -1,6 +1,7 @@
 set -e
 
 export MSYS2_FC_CACHE_SKIP=1
+export PY_IGNORE_IMPORTMISMATCH=1
 pacman --noconfirm -Suy
 pacman --noconfirm -S --needed mingw-w64-$MSYS2_ARCH-cairo \
     mingw-w64-$MSYS2_ARCH-$PYTHON mingw-w64-$MSYS2_ARCH-$PYTHON-pip \

--- a/.azure-pipelines/msys2.sh
+++ b/.azure-pipelines/msys2.sh
@@ -1,7 +1,7 @@
 set -e
 
 export MSYS2_FC_CACHE_SKIP=1
-pacman --noconfirm -Suy --force
+pacman --noconfirm -Suy
 pacman --noconfirm -S --needed mingw-w64-$MSYS2_ARCH-cairo \
     mingw-w64-$MSYS2_ARCH-$PYTHON mingw-w64-$MSYS2_ARCH-$PYTHON-pip \
     mingw-w64-$MSYS2_ARCH-toolchain git

--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,10 @@ def add_ext_cflags(ext, compiler):
         "-fvisibility=hidden",
     ]
 
+    args += [
+        "-std=c99",
+    ]
+
     ext.extra_compile_args += filter_compiler_arguments(compiler, args)
 
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,9 @@ def filter_compiler_arguments(compiler, args):
         extra += ['-Werror=unknown-warning-option']
     if check_argument(compiler, '-Werror=unused-command-line-argument'):
         extra += ['-Werror=unused-command-line-argument']
+    # silence clang for unused gcc CFLAGS added by Debian
+    if check_argument(compiler, '-Wno-unused-command-line-argument'):
+        extra += ['-Wno-unused-command-line-argument']
 
     # first try to remove all arguments contained in the error message
     supported = list(args)
@@ -144,11 +147,6 @@ def add_ext_cflags(ext, compiler):
     args += [
         "-Wno-missing-field-initializers",
         "-Wno-unused-parameter",
-    ]
-
-    # silence clang for unused gcc CFLAGS added by Debian
-    args += [
-        "-Wno-unused-command-line-argument",
     ]
 
     args += [


### PR DESCRIPTION
These are all the fixes for Azure gathered together and cleaned up:

 -  Don't use deprecated pacman --force option
 -  Move to C99 since 3.8 seems to require it.
 -  Cast type to (int) when getting data from enum.
 -  Move -Wno-unused-parameter to filtered compiler options.
 - Use PY_IGNORE_MISMATCH so that pytest doesn't fail on MSYS with python 3.8.