### PR TITLE
Travis - Manually set sysroot so correct OSX SDK is used.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ matrix:
     - os: osx
       osx_image: xcode10.3
       language: generic
-      env: PYVER="3" CFLAGS="-Werror -coverage"
+      env: PYVER="3" CFLAGS="-Werror -coverage -isysroot $(xcrun --show-sdk-path)" ARCHFLAGS="-isysroot $(xcrun --show-sdk-path)"
     - os: osx
       osx_image: xcode10.3
       language: generic
-      env: PYVER="2" CFLAGS="-Werror -coverage"
+      env: PYVER="2" CFLAGS="-Werror -coverage -isysroot $(xcrun --show-sdk-path)" ARCHFLAGS="-isysroot $(xcrun --show-sdk-path)"
 
 
 install:


### PR DESCRIPTION
This attempts to fix #162 by adding the MacOS SDK to CFLAGS and ARCH, from xcrun --show-sdk-path.

The tests in CI pass... but the warning is still logged, and the wrong SDK passed in, from somewhere.

This seems like an improvement, but I'm not sure where the wrong SDK is coming from.

Upgrading OSX to a 11.3 version seems to workaround then that might be too new if we are trying to do something like build binary wheels ?