### PR TITLE
Replace % formatting with fstrings.

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -111,7 +111,7 @@ Creating an ImageSurface from a PIL Image:
             :param alpha: 0..1 alpha to add to non-alpha images
             :param format: Pixel format for output surface
             """
-            assert format in (cairo.FORMAT_RGB24, cairo.FORMAT_ARGB32), "Unsupported pixel format: %s" % format
+            assert format in (cairo.FORMAT_RGB24, cairo.FORMAT_ARGB32), f"Unsupported pixel format: {format}"
             if 'A' not in im.getbands():
                 im.putalpha(int(alpha * 256.))
             arr = bytearray(im.tobytes('raw', 'BGRa'))

--- a/examples/cairo_snippets/snippets_pdf.py
+++ b/examples/cairo_snippets/snippets_pdf.py
@@ -13,7 +13,7 @@ from snippets import get_snippets
 
 def do_snippet(snippet):
     if verbose_mode:
-        print('processing %s' % snippet.name)
+        print(f'processing {snippet.name}')
 
     width_in_inches, height_in_inches = 2, 2
     width_in_points, height_in_points = \
@@ -24,7 +24,7 @@ def do_snippet(snippet):
         os.makedirs(os.path.join("_build", "pdf"))
     except EnvironmentError:
         pass
-    filename = os.path.join("_build", "pdf", "%s.pdf" % snippet.name)
+    filename = os.path.join("_build", "pdf", f"{snippet.name}.pdf")
 
     surface = cairo.PDFSurface(filename, width_in_points, height_in_points)
     cr = cairo.Context(surface)

--- a/examples/cairo_snippets/snippets_png.py
+++ b/examples/cairo_snippets/snippets_png.py
@@ -13,7 +13,7 @@ from snippets import get_snippets
 
 def do_snippet(snippet):
     if verbose_mode:
-        print('processing %s' % snippet.name)
+        print(f'processing {snippet.name}')
 
     width, height = 256, 256
 
@@ -29,7 +29,7 @@ def do_snippet(snippet):
         os.makedirs(os.path.join("_build", "png"))
     except EnvironmentError:
         pass
-    filename = os.path.join("_build", "png", "%s.png" % snippet.name)
+    filename = os.path.join("_build", "png", f"{snippet.name}.png")
 
     surface.write_to_png(filename)
 

--- a/examples/cairo_snippets/snippets_ps.py
+++ b/examples/cairo_snippets/snippets_ps.py
@@ -13,7 +13,7 @@ from snippets import get_snippets
 
 def do_snippet(snippet):
     if verbose_mode:
-        print('processing %s' % snippet.name)
+        print(f'processing {snippet.name}')
 
     width_in_inches, height_in_inches = 2, 2
     width_in_points, height_in_points = \
@@ -24,7 +24,7 @@ def do_snippet(snippet):
         os.makedirs(os.path.join("_build", "ps"))
     except EnvironmentError:
         pass
-    filename = os.path.join("_build", "ps", "%s.ps" % snippet.name)
+    filename = os.path.join("_build", "ps", f"{snippet.name}.ps")
 
     surface = cairo.PSSurface(filename, width_in_points, height_in_points)
     cr = cairo.Context(surface)

--- a/examples/cairo_snippets/snippets_svg.py
+++ b/examples/cairo_snippets/snippets_svg.py
@@ -13,7 +13,7 @@ from snippets import get_snippets
 
 def do_snippet(snippet):
     if verbose_mode:
-        print('processing %s' % snippet.name)
+        print(f'processing {snippet.name}')
 
     width_in_inches, height_in_inches = 2, 2
     width_in_points, height_in_points = \
@@ -24,7 +24,7 @@ def do_snippet(snippet):
         os.makedirs(os.path.join("_build", "svg"))
     except EnvironmentError:
         pass
-    filename = os.path.join("_build", "svg", "%s.svg" % snippet.name)
+    filename = os.path.join("_build", "svg", f"{snippet.name}.svg")
 
     surface = cairo.SVGSurface(filename, width_in_points, height_in_points)
     cr = cairo.Context(surface)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def pkg_config_version_check(pkg, version):
         "pkg-config",
         "--print-errors",
         "--exists",
-        '%s >= %s' % (pkg, version),
+        f'{pkg} >= {version}',
     ]
 
     _check_output(command)


### PR DESCRIPTION
Use fstrings instead of % formatting, except for logging and in the C API.