### PR TITLE
meson: add 'tests' option to skip tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,4 +124,7 @@ configure_file(input : 'PKG-INFO.in',
   install_dir : python.get_install_dir(pure : false))
 
 subdir('cairo')
-subdir('tests')
+
+if get_option('tests')
+  subdir('tests')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('python', type : 'string', value : 'python3')
+option('tests', type : 'boolean', value : true, description : 'build unit tests')


### PR DESCRIPTION
Useful when used as part of a subproject, as tests will
fail if certain python modules aren't installed.