### PR TITLE
Update Image Link README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://cdn.rawgit.com/pygobject/pycairo/master/docs/images/pycairo.svg
+.. image:: https://raw.githubusercontent.com/pygobject/pycairo/master/docs/images/pycairo.svg
    :align: center
    :width: 370px
 
@@ -23,7 +23,7 @@ Installing Pycairo requires cairo including its headers. For more info see
 
 ----
 
-.. image:: https://cdn.rawgit.com/pygobject/pycairo/master/docs/images/example.svg
+.. image:: https://raw.githubusercontent.com/pygobject/pycairo/master/docs/images/example.svg
    :align: right
    :width: 200px
 


### PR DESCRIPTION
Update image link in Readme so that it shows up in [PyPI](https://pypi.org/project/pycairo/). See the image below. 
![err](https://user-images.githubusercontent.com/49693820/85948956-7266bc80-b971-11ea-8917-96a4becd202a.PNG)
The link is shown instead of Image.