### PR TITLE
Use Github Actions for building Wheels and not Travis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,27 +1,30 @@
 name: Build
 
-on: [push]
+on: 
+  push:
+      branches:
+        - master
+  pull_request:
+      branches:
+        - master
 
 jobs:
   build_wheels:
-    name: Build wheels for Windows on ${{ matrix.python-version }}
+    name: Build wheels and Test for Windows on ${{ matrix.python-version }}
     runs-on: windows-latest
     env:
       CAIRO_VERSION: "1.17.2"
-      TOKENACCESS: ${{ secrets.GITHUB_TOKEN }} 
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
-
     steps:
       - uses: actions/checkout@v2
       - name: Download and extract Cairo Binary
         run: |
-          
+          #TODO: Change below URL on new cairo release
           curl -L https://github.com/preshing/cairo-windows/releases/download/with-tee/cairo-windows-1.17.2.zip -o cairocomplied.zip
           7z x cairocomplied.zip
           Move-Item 'cairo-windows-*' "cairocomplied"
-          #Move-Item 'cairocomplied\include\cairo\*' "cairocomplied\include"
           tree
       - name: Set up Python ${{ matrix.python-version }} for x64
         uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,83 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build_wheels:
+    name: Build wheels for Windows on ${{ matrix.python-version }}
+    runs-on: windows-latest
+    env:
+      CAIRO_VERSION: "1.17.2"
+      TOKENACCESS: ${{ secrets.GITHUB_TOKEN }} 
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download and extract Cairo Binary
+        run: |
+          
+          curl -L https://github.com/preshing/cairo-windows/releases/download/with-tee/cairo-windows-1.17.2.zip -o cairocomplied.zip
+          7z x cairocomplied.zip
+          Move-Item 'cairo-windows-*' "cairocomplied"
+          #Move-Item 'cairocomplied\include\cairo\*' "cairocomplied\include"
+          tree
+      - name: Set up Python ${{ matrix.python-version }} for x64
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
+      - name: Build x64 Build
+        run: |
+          $env:INCLUDE="$PWD\cairocomplied\include\"
+          $env:LIB="$PWD\cairocomplied\lib\x64\"
+          Copy-Item "$PWD\cairocomplied\lib\x64\cairo.dll" "cairo\cairo.dll"
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade wheel
+          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade pytest flake8 "sphinx<3" sphinx_rtd_theme coverage codecov hypothesis attrs
+          python -m pip install --upgrade mypy || true
+          python -m pip install --upgrade pygame
+          python -m coverage run --branch setup.py test
+          python -m codecov --required
+          python -m flake8 .
+          python setup.py sdist
+          python setup.py bdist
+          python setup.py install --root=_root
+          python setup.py install --root="$(pwd)"/_root_abs
+          python setup.py bdist_wheel
+          python setup.py install --root=_root_setup
+          python -m pip install .
+          python -m sphinx -W -a -E -b html -n docs docs/_build
+      - name: Set up Python ${{ matrix.python-version }} for x86
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x86'
+      - name: Build x86 Build
+        run: |
+          $env:INCLUDE="$PWD\cairocomplied\include\"
+          $env:LIB="$PWD\cairocomplied\lib\x86\"
+          Copy-Item "cairocomplied\lib\x86\cairo.dll" "cairo\cairo.dll"
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade wheel
+          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade pytest flake8 "sphinx<3" sphinx_rtd_theme coverage codecov hypothesis attrs
+          python -m pip install --upgrade mypy || true
+          python -m pip install --upgrade pygame
+          python -m coverage run --branch setup.py test
+          python -m codecov --required
+          python -m flake8 .
+          python setup.py sdist
+          python setup.py bdist
+          python setup.py install --root=_root
+          python setup.py install --root="$(pwd)"/_root_abs
+          python setup.py bdist_wheel
+          python setup.py install --root=_root_setup
+          python -m pip install .
+          python -m sphinx -W -a -E -b html -n docs docs/_build
+      - uses: actions/upload-artifact@v2
+        with:
+         name: wheels-${{ matrix.python-version }}
+         path: dist/pycairo*.whl

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,94 +1,54 @@
 matrix:
   include:
-    - os: windows
-      language: sh
-      python: 3.6
-      name: Build on x64 Python 3.6.8 in Windows
-      env: ARCH="x64" CAIRO_VERSION="1.17.2" PYTHON_PACKAGE="python" PYTHON_VERSION="3.6.8"
-    - os: windows
-      language: sh
-      python: 3.7
-      name: Build on x64 Python 3.7.7 in Windows
-      env: ARCH="x64" CAIRO_VERSION="1.17.2" PYTHON_PACKAGE="python" PYTHON_VERSION="3.7.7" 
-    - os: windows
-      language: sh
-      python: 3.8
-      name: Build on x64 Python 3.8.3 in Windows
-      env: ARCH="x64" CAIRO_VERSION="1.17.2" PYTHON_PACKAGE="python" PYTHON_VERSION="3.8.3"
-    - os: windows
-      language: sh
-      python: 3.6
-      name: Build on x86 Python 3.6.8 in Windows
-      env: ARCH="x86" CAIRO_VERSION="1.17.2" PYTHON_PACKAGE="pythonx86" PYTHON_VERSION="3.6.8"
-    - os: windows
-      language: sh
-      python: 3.7
-      name: Build on x86 Python 3.7.7 in Windows
-      env: ARCH="x86" CAIRO_VERSION="1.17.2" PYTHON_PACKAGE="pythonx86" PYTHON_VERSION="3.7.7" 
-    - os: windows
-      language: sh
-      python: 3.8
-      name: Build on x86 Python 3.8.3 in Windows
-      env: ARCH="x86" CAIRO_VERSION="1.17.2" PYTHON_PACKAGE="pythonx86" PYTHON_VERSION="3.8.3" 
     - os: linux
       dist: trusty
       language: python
-      python: 3.5
-      name: Build on Python 3.5 in Trusty Linux
+      python: "3.5"
       env: CFLAGS="-Werror -coverage"
     - os: linux
       dist: trusty
       language: python
-      python: 3.6
-      name: Build on Python 3.6 in Trusty Linux
+      python: "3.6"
       env: CFLAGS="-Werror -coverage"
     - os: linux
       dist: xenial
       language: python
-      python: 3.7
-      name: Build on Python 3.7 in Xenial Linux
+      python: "3.7"
       env: CFLAGS="-Werror -coverage"
     - os: linux
       dist: xenial
       language: python
-      python: 3.8
-      name: Build on Python 3.8 in Xenial Linux
+      python: "3.8"
+      env: CFLAGS="-Werror -coverage"
+    - os: linux
+      dist: xenial
+      language: python
+      python: "pypy3"
       env: CFLAGS="-Werror -coverage"
     - os: osx
       osx_image: xcode11.3
       language: generic
-      name: Build on Python 3.8 in Mac OSX xcode11.3
       env: CFLAGS="-Werror -coverage"
 
 
 install:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then travis_retry sudo apt-get update -q; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then travis_retry sudo apt-get install -y libcairo2-dev; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install pkg-config || true; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install cairo || true; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew unlink python@2 || true; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install python || true; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then python3 -m pip install virtualenv; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then virtualenv ../venv -p python3; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then source ../venv/bin/activate; fi
-  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then curl -sS -L https://aka.ms/nugetclidl -o $TMP/nuget.exe; fi
-  # TODO - future versions of cairo-windows will build with tee support so should not be tagged 'with-tee'
-  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then curl -sS -L https://github.com/preshing/cairo-windows/releases/download/with-tee/cairo-windows-$CAIRO_VERSION.zip -o $TMP/cairo-windows-$CAIRO_VERSION.zip; fi
-  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then 7z x $TMP/cairo-windows-$CAIRO_VERSION.zip -o$TMP; fi
-  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then $TMP/nuget install $PYTHON_PACKAGE -Version $PYTHON_VERSION -OutputDirectory $TMP/nuget-$ARCH; fi
-  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then export INCLUDE="$TMP/cairo-windows-$CAIRO_VERSION/include"; fi
-  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then export LIB=$TMP/cairo-windows-$CAIRO_VERSION/lib/$ARCH; fi
-  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then export PATH=$TMP/nuget-$ARCH/$PYTHON_PACKAGE.$PYTHON_VERSION/tools/:$TMP/nuget-$ARCH/$PYTHON_PACKAGE.$PYTHON_VERSION/tools/Scripts:$PATH; fi
-  - python -m pip install --upgrade wheel
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis_retry sudo apt-get update -q; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis_retry sudo apt-get install -y libcairo2-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install pkg-config || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew unlink python@2 || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 -m pip install virtualenv; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then virtualenv ../venv -p python3; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source ../venv/bin/activate; fi
   - python -m pip install --upgrade setuptools
   - python -m pip install --upgrade pytest flake8 "sphinx<3" sphinx_rtd_theme coverage codecov hypothesis attrs
   - python -m pip install --upgrade mypy || true
   - if [[ "$TRAVIS_OS_NAME" != "osx" ]] && [[ "$TRAVIS_PYTHON_VERSION" != "3.8" ]] && [[ "${TRAVIS_PYTHON_VERSION:0:4}" != "pypy" ]]; then python -m pip install --upgrade pygame; fi
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]] ; then cp $TMP/cairo-windows-$CAIRO_VERSION/lib/$ARCH/cairo.dll cairo/cairo.dll; fi
   - python -m coverage run --branch setup.py test
   - python -m codecov --required || true
   - python -m flake8 .
@@ -96,17 +56,8 @@ script:
   - python setup.py bdist
   - python setup.py install --root=_root
   - python setup.py install --root="$(pwd)"/_root_abs
+  - python setup.py bdist_egg
   - python setup.py bdist_wheel
   - python setup.py install --root=_root_setup
   - if [[ "${TRAVIS_PYTHON_VERSION:0:4}" != "pypy" ]] ; then python -m pip install .; fi
   - python -m sphinx -W -a -E -b html -n docs docs/_build
-
-
-deploy:
-  if: TRAVIS_OS_NAME = windows
-  provider: releases
-  file_glob: true
-  api_key: $GITHUBOAUTHTOKEN
-  file: dist/*.whl
-  skip_cleanup: true
-  draft: true


### PR DESCRIPTION
This PR is:
- continuation of #191 
- Fixes #19 
- Builds and test windows wheels using Github Actions 
- Revert `.travis.yml` to how it was originally.
- Uploads as Artifact after each build

TODO:
- Correct it to upload to releases. 

cc
@stuaxo 