### PR TITLE
Require cairo 1.15.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 |
 
 Pycairo is a Python module providing bindings for the `cairo graphics library
-<https://cairographics.org/>`__. It depends on **cairo >= 1.13.1** and works
+<https://cairographics.org/>`__. It depends on **cairo >= 1.15.10** and works
 with **Python 3.6+**. Pycairo, including this documentation, is licensed under
 the `LGPL-2.1-only OR MPL-1.1 <https://spdx.org/ids-how>`__.
 

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
   ],
 )
 
-cair_version_req = '>=1.13.1'
+cair_version_req = '>=1.15.10'
 
 pymod = import('python')
 python = pymod.find_installation(get_option('python'))

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from distutils import sysconfig
 
 
 PYCAIRO_VERSION = '1.19.2'
-CAIRO_VERSION_REQUIRED = '1.13.1'
+CAIRO_VERSION_REQUIRED = '1.15.10'
 XPYB_VERSION_REQUIRED = '1.3'
 
 


### PR DESCRIPTION
We now require Python 3.6 and nearly all distros shipping 3.6+ also
have cairo 1.15.10+, so try bumping that requirement as well.