### PR TITLE
Check that file objects take/return byte objects when passing them to pycairo

### DIFF
--- a/cairo/device.c
+++ b/cairo/device.c
@@ -250,7 +250,7 @@ script_device_new (PyTypeObject *type, PyObject *args, PyObject *kwds) {
         PyErr_SetString (PyExc_TypeError,
                          "ScriptDevice takes one argument which must be "
                          "a filename, file object, or a file-like object "
-                         "which has a \"write\" method (like StringIO)");
+                         "which has a \"write\" method (like BytesIO) taking bytes.");
         return NULL;
     }
   }

--- a/cairo/misc.c
+++ b/cairo/misc.c
@@ -154,40 +154,37 @@ Pycairo_fspath_converter (PyObject *obj, char** result) {
  */
 int
 Pycairo_writer_converter (PyObject *obj, PyObject** file) {
-    PyObject *attr;
+    PyObject *res;
 
-    attr = PyObject_GetAttrString (obj, "write");
-    if (attr == NULL)
-        return 0;
+    /* Check that the file is opened in binary mode by writing a zero length
+     * bytes object to it */
+    res = PyObject_CallMethod (obj, "write", "(y#)", "", (Py_ssize_t) 0);
+    if (res == NULL)
+        return  0;
+    Py_DECREF (res);
 
-    if (!PyCallable_Check (attr)) {
-        Py_DECREF (attr);
-        PyErr_SetString (
-            PyExc_TypeError, "'write' attribute not callable");
-        return 0;
-    }
-
-    Py_DECREF (attr);
     *file = obj;
     return 1;
 }
 
 int
 Pycairo_reader_converter (PyObject *obj, PyObject** file) {
-    PyObject *attr;
+    PyObject *res;
 
-    attr = PyObject_GetAttrString (obj, "read");
-    if (attr == NULL)
+    /* Check that the file is opened in binary mode by reading a zero length
+     * bytes object from it */
+    res = PyObject_CallMethod (obj, "read", "(i)", (int) 0);
+    if (res == NULL)
         return 0;
 
-    if (!PyCallable_Check (attr)) {
-        Py_DECREF (attr);
+    if (!PyBytes_Check (res)) {
+        Py_DECREF (res);
         PyErr_SetString (
-            PyExc_TypeError, "'read' attribute not callable");
+            PyExc_TypeError, "'read' does not return bytes");
         return 0;
     }
+    Py_DECREF (res);
 
-    Py_DECREF (attr);
     *file = obj;
     return 1;
 }

--- a/cairo/surface.c
+++ b/cairo/surface.c
@@ -418,7 +418,7 @@ surface_write_to_png (PycairoSurface *o, PyObject *args) {
       PyErr_SetString (PyExc_TypeError,
                        "Surface.write_to_png takes one argument which must be "
                        "a filename, file object, or a file-like object "
-                       "which has a \"write\" method (like StringIO)");
+                       "which has a \"write\" method (like BytesIO) taking bytes");
       return NULL;
     }
   }
@@ -970,7 +970,7 @@ image_surface_create_from_png (PyTypeObject *type, PyObject *args) {
       PyErr_SetString(PyExc_TypeError,
                       "ImageSurface.create_from_png argument must be a "
                       "filename (str), file object, or an object that has a "
-                      "\"read\" method (like StringIO)");
+                      "\"read\" method (like BytesIO) returning bytes.");
       return NULL;
     }
   }
@@ -1236,7 +1236,7 @@ pdf_surface_new (PyTypeObject *type, PyObject *args, PyObject *kwds) {
                       "PDFSurface argument 1 must be "
                       "None, or a filename (str), or "
                       "a file object, or an object that has a "
-                      "\"write\" method (like StringIO).");
+                      "\"write\" method (like BytesIO) taking bytes.");
       return NULL;
     }
   }
@@ -1600,7 +1600,7 @@ ps_surface_new (PyTypeObject *type, PyObject *args, PyObject *kwds) {
                       "PSSurface argument 1 must be "
                       "None, or a filename (str), or "
                       "a file object, or an object that has a "
-                      "\"write\" method (like StringIO).");
+                      "\"write\" method (like BytesIO) taking bytes.");
       return NULL;
     }
   }
@@ -1947,7 +1947,7 @@ svg_surface_new (PyTypeObject *type, PyObject *args, PyObject *kwds) {
                       "SVGSurface argument 1 must be "
                       "None, or a filename (str), or "
                       "a file object, or an object that has a "
-                      "\"write\" method (like StringIO).");
+                      "\"write\" method (like BytesIO) taking bytes.");
       return NULL;
     }
   }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -159,8 +159,9 @@ def test_image_surface_get_data():
 def test_surface_file_obj_error():
     class Fail(object):
 
-        def write(*args):
-            raise IOError
+        def write(obj, data):
+            if data:
+                raise IOError
 
     cairo.PDFSurface(Fail(), 100, 100)
     cairo.PSSurface(Fail(), 100, 100)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -57,6 +57,9 @@ def test_script_device():
     with pytest.raises(TypeError):
         cairo.ScriptDevice()
 
+    with pytest.raises(TypeError):
+        cairo.ScriptDevice(io.StringIO())
+
     with pytest.raises((ValueError, TypeError)):
         cairo.ScriptDevice("\x00")
 

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -166,6 +166,14 @@ def test_surface_get_format():
     assert isinstance(surface.get_format(), cairo.Format)
 
 
+def test_pdf_get_error():
+    cairo.PDFSurface(io.BytesIO(), 10, 10)
+    with pytest.raises(TypeError):
+        cairo.PDFSurface(object(), 10, 10)
+    with pytest.raises(TypeError):
+        cairo.PDFSurface(io.StringIO(), 10, 10)
+
+
 def test_pdf_get_versions():
     versions = cairo.PDFSurface.get_versions()
     assert isinstance(versions, list)
@@ -295,6 +303,14 @@ def test_pdf_version_to_string():
         cairo.PDFSurface.version_to_string(-1)
     with pytest.raises(TypeError):
         cairo.PDFSurface.version_to_string(object())
+
+
+def test_ps_surface_error():
+    cairo.PSSurface(io.BytesIO(), 10, 10)
+    with pytest.raises(TypeError):
+        cairo.PSSurface(object(), 10, 10)
+    with pytest.raises(TypeError):
+        cairo.PSSurface(io.StringIO(), 10, 10)
 
 
 def test_ps_surface_misc():
@@ -526,6 +542,8 @@ def test_image_surface_png_obj_roundtrip():
         cairo.ImageSurface.create_from_png("\x00")
     with pytest.raises(TypeError):
         cairo.ImageSurface.create_from_png(object())
+    with pytest.raises(TypeError):
+        cairo.ImageSurface.create_from_png(io.StringIO())
 
 
 def test_image_surface_png_file_roundtrip():
@@ -651,6 +669,9 @@ def test_mark_dirty_rectangle(surface):
 def test_write_to_png(image_surface):
     with pytest.raises(TypeError):
         image_surface.write_to_png()
+
+    with pytest.raises(TypeError):
+        image_surface.write_to_png(io.StringIO())
 
     with pytest.raises((ValueError, TypeError)) as excinfo:
         image_surface.write_to_png("\x00")


### PR DESCRIPTION
Otherwise they get used the first time in the cairo callback where all we
can do is set a cairo error, but can't pass the real error to the caller.

This tries to read/write a zero length bytes object when the object is
passed to pycairo, so we can raise an exception that's helpful to the user.

Fixes #157