### PR TITLE
Add a basic pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include NEWS
 include README.rst
 include MANIFEST.in
 include PKG-INFO.in
+include pyproject.toml
 include setup.cfg
 include meson_options.txt
 recursive-include . meson.build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]


### PR DESCRIPTION
This will enable isolated builds in pip when installing pycairo.
Ideally this shouldn't make a difference, we'll see.