### PR TITLE
Make import_cairo inline in addition to static

### DIFF
--- a/cairo/pycairo.h
+++ b/cairo/pycairo.h
@@ -252,7 +252,7 @@ Pycairo_CAPI_t *Pycairo_CAPI;
 /* Return -1 on error, 0 on success.
  * PyCapsule_Import will set an exception if there's an error.
  */
-static int
+static inline int
 import_cairo(void)
 {
   Pycairo_CAPI = (Pycairo_CAPI_t*) PyCapsule_Import("cairo.CAPI", 0);


### PR DESCRIPTION
This prevents the message `warning: ‘int import_cairo()’ defined but not used` when compiling [graph-tool](https://graph-tool.skewed.de/) with GCC. The warning is triggered because [graph_cairo_draw.cc](https://git.skewed.de/count0/graph-tool/-/blob/master/src/graph/draw/graph_cairo_draw.cc) needs `PycairoContext_GET` but does not need to call `import_cairo`.