### PR TITLE
mypy: exlude examples

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,4 @@ disallow_any_decorated = True
 disallow_any_explicit = False
 strict_optional = True
 follow_imports = silent
+exclude = examples/


### PR DESCRIPTION
mypy 0.800 started to scan those, but they are not typed in any way