### PR TITLE
Don't run mypy via pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         shell: msys2 {0}
         run: |
-          python -m pip install pytest coverage hypothesis mypy
+          python -m pip install pytest coverage hypothesis
 
       - name: Run tests
         shell: msys2 {0}
@@ -68,6 +68,7 @@ jobs:
     - name: Run tests
       run: |
         poetry run python setup.py test
+        poetry run mypy .
 
   ubuntu:
     runs-on: ubuntu-latest
@@ -89,9 +90,6 @@ jobs:
         sudo apt-get install -y libcairo2-dev
         python -m pip install --upgrade setuptools
         python -m pip install --upgrade pytest flake8 sphinx sphinx_rtd_theme coverage hypothesis attrs wheel
-        if [[ "${{ matrix.python-version }}" != "pypy3" ]]; then
-          python -m pip install --upgrade mypy
-        fi
         if [[ "${{ matrix.python-version }}" != "pypy3" ]] && [[ "${{ matrix.python-version }}" != "3.8" ]] && [[ "${{ matrix.python-version }}" != "3.9.0-rc.1 - 3.9" ]]; then
           python -m pip install --upgrade pygame
         fi
@@ -148,7 +146,6 @@ jobs:
           python -m pip install --upgrade wheel
           python -m pip install --upgrade setuptools
           python -m pip install --upgrade pytest flake8 sphinx sphinx_rtd_theme coverage hypothesis attrs
-          python -m pip install --upgrade mypy || true
           python -m pip install --upgrade pygame
           python -m coverage run --branch setup.py test
           python -m coverage xml -i
@@ -180,7 +177,6 @@ jobs:
           python -m pip install --upgrade wheel
           python -m pip install --upgrade setuptools
           python -m pip install --upgrade pytest flake8 sphinx sphinx_rtd_theme coverage hypothesis attrs
-          python -m pip install --upgrade mypy || true
           python -m pip install --upgrade pygame
           python -m coverage run --branch setup.py test
           python -m coverage xml -i
@@ -220,7 +216,6 @@ jobs:
           source ../venv/bin/activate
           python -m pip install --upgrade setuptools
           python -m pip install --upgrade pytest flake8 sphinx sphinx_rtd_theme coverage hypothesis attrs wheel
-          python -m pip install --upgrade mypy || true
           # run tests
           python -m coverage run --branch setup.py test
           python -m coverage xml -i

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,21 +1,8 @@
 import os
 import io
-import sys
 import types
 
 import cairo
-import pytest
-
-mypy = pytest.importorskip("mypy.api")
-pytestmark = pytest.mark.skipif(
-    sys.version_info[:2] < (3, 6), reason="Py3.6 only")
-pytestmark
-
-
-def test_mypy():
-    out, err, status = mypy.run([os.path.dirname(cairo.__path__[0])])
-    if status != 0:
-        raise Exception("\n" + "\n".join([out, err]))
 
 
 def test_typing():


### PR DESCRIPTION
There is a good chance that newer mypy gives new errors and breaks things.
One can run mypy either via the IDE or just "mypy ."

In CI we limit it to poetry with a fixed version.

Fixes #229