### PR TITLE
docs: start using autodoc on the typing stubs

### DIFF
--- a/cairo/__init__.pyi
+++ b/cairo/__init__.pyi
@@ -42,42 +42,43 @@ def cairo_version_string() -> str:
 
 class Path:
     """
-    Path cannot be instantiated directly, it is created by calling `Context.copy_path()` and `Context.copy_path_flat()`.
+    *Path* cannot be instantiated directly, it is created by calling
+    :meth:`Context.copy_path` and :meth:`Context.copy_path_flat`.
 
-    `str(path)` lists the path elements.
+    str(path) lists the path elements.
 
-    See path attributes
+    See :class:`path attributes <cairo.PathDataType>`
 
-    `Path` is an iterator.
+    Path is an iterator.
+
+    See examples/warpedtext.py for example usage.
     """
 
 class Rectangle(Tuple[float, float, float, float]):
     """
-    New in version 1.15: In prior versions a (float, float, float, float) tuple was used instead of `Rectangle`.
+    .. versionadded:: 1.15
+        In prior versions a (float, float, float, float) tuple was
+        used instead of :class:`Rectangle`.
 
     A data structure for holding a rectangle.
-
-    Parameters
-    ----------
-    >>> x (float)\n
-    X coordinate of the left side of the rectangle.
-    >>> y (float)\n
-    Y coordinate of the the top side of the rectangle.
-    >>> width (float)\n
-    Width of the rectangle.
-    >>> height (float)\n
-    Height of the rectangle.
-
-    Returns
-    -------
-    >>> cairo.Rectangle\n
-    A newly created `Rectangle` instance.
     """
+
     x: float = ...
     y: float = ...
     width: float = ...
     height: float = ...
-    def __init__(self, x: float, y: float, width: float, height: float) -> None: ...
+
+    def __init__(self, x: float, y: float, width: float, height: float) -> None:
+        """
+        :param x:
+            X coordinate of the left side of the rectangle
+        :param y:
+            Y coordinate of the the top side of the rectangle
+        :param width:
+            width of the rectangle
+        :param height:
+            height of the rectangle
+        """
 
 class _IntEnum(int):
     def __init__(self, value: int) -> None: ...

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,29 @@
 # -*- coding: utf-8 -*-
 
+import os
+import types
+import sys
+
+
+dir_ = os.path.dirname(os.path.realpath(__file__))
+
+
+def exec_module(path):
+    globals_ = {}
+    with open(path, encoding="utf-8") as h:
+        exec(h.read(), globals_)
+    module = types.ModuleType("")
+    module.__dict__.update(globals_)
+    return module
+
+
+sys.modules["cairo"] = exec_module(os.path.join(dir_, "..", "cairo", "__init__.pyi"))
+
+
 extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.extlinks',
+    'sphinx.ext.autodoc',
 ]
 intersphinx_mapping = {
     'python3': ('https://docs.python.org/3', None),
@@ -34,3 +55,5 @@ extlinks = {
     'user': ('https://github.com/%s', ''),
 }
 suppress_warnings = ["image.nonlocal_uri"]
+
+autoclass_content = 'both'

--- a/docs/reference/paths.rst
+++ b/docs/reference/paths.rst
@@ -9,15 +9,4 @@ Paths
 class Path()
 ============
 
-.. class:: Path()
-
-   *Path* cannot be instantiated directly, it is created by calling
-   :meth:`Context.copy_path` and :meth:`Context.copy_path_flat`.
-
-   str(path) lists the path elements.
-
-   See :class:`path attributes <cairo.PathDataType>`
-
-   Path is an iterator.
-
-   See examples/warpedtext.py for example usage.
+.. autoclass:: cairo.Path

--- a/docs/reference/rectangle.rst
+++ b/docs/reference/rectangle.rst
@@ -9,36 +9,6 @@ Rectangle
 class Rectangle(tuple)
 ======================
 
-.. class:: Rectangle(x, y, width, height)
-
-    :param float x:
-        X coordinate of the left side of the rectangle
-    :param float y:
-        Y coordinate of the the top side of the rectangle
-    :param float width:
-        width of the rectangle
-    :param float height:
-        height of the rectangle
-    :rtype: Rectangle
-
-    .. versionadded:: 1.15
-        In prior versions a (float, float, float, float) tuple was used instead
-        of :class:`Rectangle`.
-
-    A data structure for holding a rectangle.
-
-    .. attribute:: x
-
-        :class:`float`
-
-    .. attribute:: y
-
-        :class:`float`
-
-    .. attribute:: width
-
-        :class:`float`
-
-    .. attribute:: height
-
-        :class:`float`
+.. autoclass:: cairo.Rectangle
+    :members:
+    :undoc-members:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,4 +28,4 @@ disallow_any_decorated = True
 disallow_any_explicit = False
 strict_optional = True
 follow_imports = silent
-exclude = ^(examples/|build/)
+exclude = ^(examples/|build|docs/)


### PR DESCRIPTION
Instead of having docs in two places write the docs in the .pyi
file and pull them into sphinx via autodoc.

This means we have to use rst in the docstrings (unless we use some
sphinx plugin to default to another syntax) but at least the docs
are only in one place.

This only converts things for two small classes, just to show
how it would work.