### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -535,6 +535,9 @@ def main():
         name="pycairo",
         version=PYCAIRO_VERSION,
         url="https://pycairo.readthedocs.io",
+        project_urls={
+            'Source': 'https://github.com/pygobject/pycairo',
+        },
         description="Python interface for cairo",
         long_description=long_description,
         maintainer="Christoph Reiter",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.