### PR TITLE
Drop some workarounds for old PyPy bugs

### DIFF
--- a/cairo/misc.c
+++ b/cairo/misc.c
@@ -33,18 +33,11 @@
 
 #include "private.h"
 
-/* PyOS_FSPath() was missing in PyPy for some time:
- * https://foss.heptapod.net/pypy/pypy/-/issues/2961 */
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 6 && (!defined(PYPY_VERSION) || PYPY_VERSION_NUM >= 0x07030000)
-#define HAS_FSPATH_SUPPORT
-#endif
-
 /* Returns 1 if the object has the correct file type for a filesystem path.
  * Parsing it with Pycairo_fspath_converter() might still fail.
  */
 int
 Pycairo_is_fspath (PyObject *obj) {
-#if defined(HAS_FSPATH_SUPPORT)
     PyObject *real = PyOS_FSPath (obj);
     if (real == NULL) {
         PyErr_Clear ();
@@ -53,9 +46,6 @@ Pycairo_is_fspath (PyObject *obj) {
         Py_DECREF (real);
         return 1;
     }
-#else
-    return (PyBytes_Check (obj) || PyUnicode_Check (obj));
-#endif
 }
 
 #if !defined(MS_WINDOWS)
@@ -64,9 +54,7 @@ static int
 Pycairo_PyUnicode_FSConverter(PyObject* obj, void* result) {
     int res;
     PyObject *real = NULL;
-#ifdef HAS_FSPATH_SUPPORT
     real = PyOS_FSPath (obj);
-#endif
     if (real == NULL) {
         PyErr_Clear ();
         return PyUnicode_FSConverter (obj, result);
@@ -84,9 +72,7 @@ static int
 Pycairo_PyUnicode_FSDecoder(PyObject* obj, void* result) {
     int res;
     PyObject *real = NULL;
-#ifdef HAS_FSPATH_SUPPORT
     real = PyOS_FSPath (obj);
-#endif
     if (real == NULL) {
         PyErr_Clear ();
         return PyUnicode_FSDecoder (obj, result);


### PR DESCRIPTION
Old PyPy didn't have PyOS_FSPath(), but that is fixed in all PyPy
versions supporting Python 3.7+ which is what we require now.
So get rid of it.