### PR TITLE
Fix incorrect interface for Matrix constructor

### DIFF
--- a/cairo/__init__.pyi
+++ b/cairo/__init__.pyi
@@ -958,7 +958,7 @@ class Matrix:
     https://www.cairographics.org/cookbook/matrix_transform/
     """
 
-    def __init__(self, xx: float = 1.0, yx: float = 0.0, yy: float = 1.0, x0: float = 0.0, y0: float = 0.0) -> None:
+    def __init__(self, xx: float = 1.0, yx: float = 0.0, xy: float = 0.0, yy: float = 1.0, x0: float = 0.0, y0: float = 0.0) -> None:
         """
         :param xx: xx component of the affine transformation
         :param yx: yx component of the affine transformation


### PR DESCRIPTION
The cairo.Matrix constructor interface defined in \_\_init\_\_.pyi was
defined incorrectly. This was causing PyCharm to complain about
unexpected arguments when calling the full Matrix constructor
explicitly, despite the code working as expected (and as
documented).
