### PR TITLE
Windows: fix DLL not found error in Python 3.8+

### DIFF
--- a/cairo/__init__.py
+++ b/cairo/__init__.py
@@ -1,4 +1,24 @@
-from ._cairo import *  # noqa: F401,F403
+from pathlib import Path
+
+import os
+import sys
+
+if sys.platform == "win32" and sys.version_info >= (3, 8):
+    env_path = os.environ.get("PATH", "").split(os.pathsep)
+    first_gtk_dll_path = next(
+            filter(
+                lambda path: path is not None
+                and Path.is_file(Path(path) / "cairo.dll"),
+                env_path,
+            ),
+            None,
+    )
+    if first_gtk_dll_path:
+        with os.add_dll_directory(first_gtk_dll_path):
+            from ._cairo import *  # noqa: F401,F403
+
+else:
+    from ._cairo import *  # noqa: F401,F403
 
 
 def get_include():


### PR DESCRIPTION
This upstreams a patch from gvsbuild. In Python 3.8, a new os.add_dll_directory method was added to make loading DLLs in Windows more consistent. The impact of this is that even if I compile GTK successfully with MSVC, and add it to the Path, INCLUDE, and LIB, I am still not able to pip install pycairo in Windows and having a working application. This finds the first GTK DLL location from the Windows PATH variable.