### PR TITLE
docs: add an example for how to convert a surface to pillow

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -102,10 +102,11 @@ Pillow (PIL) & Cairo
 
 Creating an ImageSurface from a PIL Image:
     .. code:: python
-        
+
+        import cairo
         import PIL.Image as Image
 
-        def from_pil(im, alpha=1.0, format=cairo.FORMAT_ARGB32):
+        def from_pil(im: Image, alpha: float=1.0, format: cairo.Format=cairo.FORMAT_ARGB32) -> cairo.ImageSurface:
             """
             :param im: Pillow Image
             :param alpha: 0..1 alpha to add to non-alpha images
@@ -133,6 +134,38 @@ Creating an ImageSurface from a PIL Image:
         im = Image.open(filename)
         surface3 = from_pil(im, alpha=0.5, format=cairo.FORMAT_ARGB32)
 
+Converting an ImageSurface to a PIL Image:
+
+    .. code:: python
+
+        import cairo
+        import PIL.Image as Image
+
+        def to_pill(surface: cairo.ImageSurface) -> Image:
+            format = surface.get_format()
+            size = (surface.get_width(), surface.get_height())
+            stride = surface.get_stride()
+
+            with surface.get_data() as memory:
+                if format == cairo.Format.RGB24:
+                    return Image.frombuffer(
+                        "RGB", size, memory.tobytes(),
+                        'raw', "BGRX", stride)
+                elif format == cairo.Format.ARGB32:
+                    return Image.frombuffer(
+                        "RGBA", size, memory.tobytes(),
+                        'raw', "BGRa", stride)
+                else:
+                    raise NotImplementedError(repr(format))
+
+        # Create an image surface from a PNG file (or any other source)
+        surface = cairo.ImageSurface.create_from_png("test.png")
+
+        # Convert to a PIL Image
+        im = to_pill(surface)
+
+        # Use Pillow to store it as a JPEG
+        im.save("result.jpg")
 
 Freetype-py & Cairo
 -------------------


### PR DESCRIPTION
In https://github.com/pygobject/pycairo/pull/280 the use case came up to save the result as a jpeg, or other formats and allow more control over the compression settings.

We don't really need to duplicate this logic with Pillow implementing it, so add an example for how to convert an image surface to a Pillow image object.