### PR TITLE
tests: don't depend on specific ref counts

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -281,8 +281,9 @@ def test_surface_get_set_mime_data_references():
     surface = cairo.ImageSurface(cairo.FORMAT_RGB24, 1, 1)
     v = memoryview(b"bla")
     x = v[:1]
-    assert sys.getrefcount(v) == 2
-    assert sys.getrefcount(x) == 2
+    recfcount_v = sys.getrefcount(v)
+    recfcount_x = sys.getrefcount(x)
+    assert recfcount_v == recfcount_x
     surface.set_mime_data("foo", v)
     surface.set_mime_data("foo2", v)
     surface.set_mime_data("foo3", x)
@@ -293,8 +294,8 @@ def test_surface_get_set_mime_data_references():
     surface.set_mime_data("foo2", None)
     surface.set_mime_data("foo3", None)
     surface.finish()
-    assert sys.getrefcount(v) == 2
-    assert sys.getrefcount(x) == 2
+    assert sys.getrefcount(v) == recfcount_v
+    assert sys.getrefcount(x) == recfcount_x
 
 
 @pytest.mark.skipif(

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -139,11 +139,11 @@ def test_tee_surface():
 @pytest.mark.skipif(not hasattr(sys, "getrefcount"), reason="PyPy")
 def test_image_surface_get_data_refcount():
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
-    assert sys.getrefcount(surface) == 2
+    refcount = sys.getrefcount(surface)
     d = surface.get_data()
-    assert sys.getrefcount(surface) == 3
+    assert sys.getrefcount(surface) != refcount
     del d
-    assert sys.getrefcount(surface) == 2
+    assert sys.getrefcount(surface) == refcount
 
 
 def test_image_surface_get_data_crasher():


### PR DESCRIPTION
These tests currently fail in CI under MSYS2. I can't reproduce the errors locally for some reason :/

But ideally we shouldn't rely on specific refcounts anyway, so just test that they either increase/decrease and return to their original value. This should ignore the cases where the ref counts start out different somehow.