### PR TITLE
tests: don't error out if cairo doesn't have all features

### DIFF
--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -36,10 +36,4 @@ def test_typing():
                 names.add(key)
         return names
 
-    # We expose all potential API in the typing stubs, so only check
-    # if it exactly matches the Python module with a new enough cairo
-    cairo_version = tuple(map(int, cairo.cairo_version_string().split(".")))
-    if cairo_version >= (1, 16, 0):
-        assert collect_names(cairo) == collect_names(mod)
-    else:
-        assert collect_names(cairo) <= collect_names(mod)
+    assert collect_names(cairo) <= collect_names(mod)


### PR DESCRIPTION
Some users might not enable all cairo features for which we provide bindings. This means we can't test everything, but we shouldn't error out either way.

Fixes #238