### PR TITLE
build: require newer meson and fix a deprecation warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'pycairo', 'c',
   version: '1.23.1',
-  meson_version: '>= 0.53.0',
+  meson_version: '>= 0.56.0',
   license: 'LGPL-2.1-only OR MPL-1.1',
   default_options: [
     'warning_level=1',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -45,6 +45,6 @@ endforeach
 
 test(
   'tests', python,
-  workdir: meson.build_root(),
+  workdir: meson.project_build_root(),
   args: ['-m', 'pytest'],
 )


### PR DESCRIPTION
project_build_root() is available since 0.56