### PR TITLE
docs: Fix build failure due to extlinks with Sphinx 6

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,10 +48,10 @@ html_static_path = [
 ]
 
 extlinks = {
-    'fdobug': ('https://bugs.freedesktop.org/show_bug.cgi?id=%s', '#fdo-'),
-    'bug': ('https://github.com/pygobject/pycairo/issues/%s', '#'),
-    'pr': ('https://github.com/pygobject/pycairo/pull/%s', '#pr-'),
-    'user': ('https://github.com/%s', ''),
+    'fdobug': ('https://bugs.freedesktop.org/show_bug.cgi?id=%s', '#fdo-%s'),
+    'bug': ('https://github.com/pygobject/pycairo/issues/%s', '#%s'),
+    'pr': ('https://github.com/pygobject/pycairo/pull/%s', '#pr-%s'),
+    'user': ('https://github.com/%s', '%s'),
 }
 suppress_warnings = ["image.nonlocal_uri"]
 


### PR DESCRIPTION
extlinks caption must be None or contain one %s.

Compatible with Sphinx >= 4.0.