### PR TITLE
CI: Update pypa/cibuildwheel to 2.15

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,14 +24,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.13
+        uses: pypa/cibuildwheel@v2.15
         env:
           CIBW_BEFORE_BUILD: "python {package}/.ci/download-cairo-win32.py"
           CIBW_BUILD: cp38-${{ matrix.platform_id }} cp39-${{ matrix.platform_id }} cp310-${{ matrix.platform_id }} cp311-${{ matrix.platform_id }} cp312-${{ matrix.platform_id }}
           CIBW_TEST_REQUIRES: pytest hypothesis attrs
           CIBW_TEST_COMMAND: bash {package}/.ci/test-wheels.sh {package}
           CIBW_ENVIRONMENT_WINDOWS: PKG_CONFIG_PATH='${{ github.workspace }}/cairo-prebuild/lib/pkgconfig' PKG_CONFIG='${{ github.workspace }}/cairo-prebuild/bin/pkgconf.exe'
-          CIBW_PRERELEASE_PYTHONS: 1
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
See https://github.com/pypa/cibuildwheel/releases/tag/v2.15.0 CIBW_PRERELEASE_PYTHONS  is no longer required now