### PR TITLE
Fix link to cairocffi

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,7 @@ pycairo distribution.
 
 Alternatives:
 
-* `cairocffi <https://cairocffi.readthedocs.io>`__ provides a large subset of
+* `cairocffi <https://doc.courtbouillon.org/cairocffi/>`__ provides a large subset of
   the pycairo API but instead of being implemented in C it uses `cffi
   <https://cffi.readthedocs.io/>`__ to talk to cairo. In case you'd prefer not
   to use a C extension then give this a try. Or if you use PyPy and want to


### PR DESCRIPTION
The link to cairocffi 404s: https://cairocffi.readthedocs.io/
The new link is from their github: https://github.com/Kozea/cairocffi