### PR TITLE
Add new font options color mode APIs

### DIFF
--- a/cairo/__init__.pyi
+++ b/cairo/__init__.pyi
@@ -350,6 +350,32 @@ class HintMetrics(_IntEnum):
     ON: "HintMetrics" = ...
     """Hint font metrics"""
 
+class ColorMode(_IntEnum):
+    """
+    Specifies if color fonts are to be rendered using the color glyphs or
+    outline glyphs. Glyphs that do not have a color presentation, and non-color
+    fonts are not affected by this font option.
+
+    .. versionadded:: 1.25 Only available with cairo 1.17.8+
+    """
+
+    DEFAULT: "ColorMode" = ...
+    """
+    Use the default color mode for font backend and target device.
+    """
+
+    NO_COLOR: "ColorMode" = ...
+    """
+    Disable rendering color glyphs. Glyphs are always rendered as outline glyphs
+    """
+
+    COLOR: "ColorMode" = ...
+    """
+    Enable rendering color glyphs. If the font contains a color presentation for
+    a glyph, and when supported by the font backend, the glyph will be rendered
+    in color.
+    """
+
 class HintStyle(_IntEnum):
     """
     These constants specify the type of hinting to do on font outlines.
@@ -1572,6 +1598,27 @@ class FontOptions:
         The subpixel order specifies the order of color elements within each
         pixel on the display device when rendering with an antialiasing mode of
         :attr:`cairo.Antialias.SUBPIXEL`.
+        """
+
+    def set_color_mode(self, color_mode: ColorMode) -> None:
+        """
+        :param color_mode: the new color mode
+
+        Sets the color mode for the font options object. This controls whether
+        color fonts are to be rendered in color or as outlines. See the
+        documentation for :class:`ColorMode` for full details.
+
+        .. versionadded:: 1.25.0 Only available with cairo 1.17.8+
+        """
+
+    def get_color_mode(self) -> ColorMode:
+        """
+        :returns: the color mode for the font options object
+
+        Gets the color mode for the font options object. See the documentation
+        for :class:`ColorMode` for full details.
+
+        .. versionadded:: 1.25.0 Only available with cairo 1.17.8+
         """
 
 class ScaledFont:
@@ -5694,3 +5741,6 @@ STATUS_DWRITE_ERROR = Status.DWRITE_ERROR
 PDF_OUTLINE_FLAG_OPEN = PDFOutlineFlags.OPEN
 PDF_OUTLINE_FLAG_BOLD = PDFOutlineFlags.BOLD
 PDF_OUTLINE_FLAG_ITALIC = PDFOutlineFlags.ITALIC
+COLOR_MODE_DEFAULT = ColorMode.DEFAULT
+COLOR_MODE_NO_COLOR = ColorMode.NO_COLOR
+COLOR_MODE_COLOR = ColorMode.COLOR

--- a/cairo/enums.c
+++ b/cairo/enums.c
@@ -206,6 +206,9 @@ DEFINE_ENUM(PSLevel)
 #ifdef CAIRO_HAS_SCRIPT_SURFACE
 DEFINE_ENUM(ScriptMode)
 #endif
+#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 17, 8)
+DEFINE_ENUM(ColorMode)
+#endif
 
 #undef DEFINE_ENUM
 
@@ -512,6 +515,13 @@ init_enums (PyObject *module) {
     ENUM(ScriptMode);
     CONSTANT(ScriptMode, SCRIPT_MODE, ASCII);
     CONSTANT(ScriptMode, SCRIPT_MODE, BINARY);
+#endif
+
+#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 17, 8)
+    ENUM(ColorMode)
+    CONSTANT(ColorMode, COLOR_MODE, DEFAULT);
+    CONSTANT(ColorMode, COLOR_MODE, NO_COLOR);
+    CONSTANT(ColorMode, COLOR_MODE, COLOR);
 #endif
 
 #undef ENUM

--- a/cairo/font.c
+++ b/cairo/font.c
@@ -673,6 +673,28 @@ font_options_get_variations (PycairoFontOptions *o, PyObject *ignored) {
 }
 #endif
 
+#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 17, 8)
+static PyObject *
+font_options_set_color_mode (PycairoFontOptions *o, PyObject *args) {
+  cairo_color_mode_t color_mode;
+  int color_mode_arg;
+
+  if (!PyArg_ParseTuple (args, "i:FontOptions.set_color_mode", &color_mode_arg))
+    return NULL;
+
+  color_mode = (cairo_color_mode_t)color_mode_arg;
+
+  cairo_font_options_set_color_mode (o->font_options, color_mode);
+  RETURN_NULL_IF_CAIRO_FONT_OPTIONS_ERROR(o->font_options);
+  Py_RETURN_NONE;
+}
+
+static PyObject *
+font_options_get_color_mode (PycairoFontOptions *o, PyObject *ignored) {
+  RETURN_INT_ENUM (ColorMode, cairo_font_options_get_color_mode (o->font_options));
+}
+#endif
+
 static PyObject *
 font_options_get_antialias (PycairoFontOptions *o, PyObject *ignored) {
   RETURN_INT_ENUM (Antialias, cairo_font_options_get_antialias (o->font_options));
@@ -820,6 +842,10 @@ static PyMethodDef font_options_methods[] = {
 #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 15, 12)
   {"get_variations",    (PyCFunction)font_options_get_variations, METH_NOARGS},
   {"set_variations",    (PyCFunction)font_options_set_variations, METH_VARARGS},
+#endif
+#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 17, 8)
+  {"get_color_mode",    (PyCFunction)font_options_get_color_mode, METH_NOARGS},
+  {"set_color_mode",    (PyCFunction)font_options_set_color_mode, METH_VARARGS},
 #endif
   {"get_antialias",     (PyCFunction)font_options_get_antialias,  METH_NOARGS},
   {"get_hint_metrics",  (PyCFunction)font_options_get_hint_metrics,

--- a/cairo/private.h
+++ b/cairo/private.h
@@ -309,6 +309,9 @@ DECL_ENUM(PSLevel)
 #ifdef CAIRO_HAS_SCRIPT_SURFACE
 DECL_ENUM(ScriptMode)
 #endif
+#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 17, 8)
+DECL_ENUM(ColorMode)
+#endif
 
 /* Use to disable deprecation warnings temporarily */
 #ifdef _MSC_VER

--- a/docs/reference/enums.rst
+++ b/docs/reference/enums.rst
@@ -110,3 +110,7 @@ as constants on the module level. See :ref:`legacy_constants`.
 .. autoclass:: PDFMetadata
     :members:
     :undoc-members:
+
+.. autoclass:: ColorMode
+    :members:
+    :undoc-members:

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -74,6 +74,10 @@ def test_aliases():
         cairo.SubpixelOrder,
     ]
 
+    if hasattr(cairo, "ColorMode"):
+        # cairo 1.17.8+
+        types_.append(cairo.ColorMode)
+
     def get_prefix(t):
         name = t.__name__
         # special case..

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -23,6 +23,22 @@ def scaled_font(font_face, font_options):
         font_face, cairo.Matrix(), cairo.Matrix(), font_options)
 
 
+@pytest.mark.skipif(not hasattr(cairo.FontOptions, "set_color_mode"),
+                    reason="too old cairo")
+def test_font_options_set_color_mode(font_options):
+    font_options.set_color_mode(cairo.ColorMode.COLOR)
+    assert font_options.get_color_mode() == cairo.ColorMode.COLOR
+    with pytest.raises(TypeError):
+        font_options.set_color_mode(object())
+
+
+@pytest.mark.skipif(not hasattr(cairo.FontOptions, "get_color_mode"),
+                    reason="too old cairo")
+def test_font_options_get_color_mode(font_options):
+    assert font_options.get_color_mode() == cairo.ColorMode.DEFAULT
+    assert isinstance(font_options.get_color_mode(), cairo.ColorMode)
+
+
 @pytest.mark.skipif(not hasattr(cairo.FontOptions, "get_variations"),
                     reason="too old cairo")
 def test_font_options_variations(font_options):


### PR DESCRIPTION
This adds:

* cairo_font_options_get_color_mode
* cairo_font_options_set_color_mode
* cairo_color_mode_t

See #309