### PR TITLE
module: reorder cairo script surface initialization

### DIFF
--- a/cairo/cairomodule.c
+++ b/cairo/cairomodule.c
@@ -210,6 +210,9 @@ PYCAIRO_MODINIT_FUNC PyInit__cairo(void)
   if (PyType_Ready(&PycairoTextExtents_Type) < 0)
     return NULL;
 
+  if (PyType_Ready(&PycairoSurface_Type) < 0)
+    return NULL;
+
 #ifdef CAIRO_HAS_SCRIPT_SURFACE
   if (PyType_Ready(&PycairoScriptDevice_Type) < 0)
     return NULL;
@@ -223,8 +226,6 @@ PYCAIRO_MODINIT_FUNC PyInit__cairo(void)
   if (PyType_Ready(&PycairoScaledFont_Type) < 0)
     return NULL;
 
-  if (PyType_Ready(&PycairoSurface_Type) < 0)
-    return NULL;
 #ifdef CAIRO_HAS_IMAGE_SURFACE
   if (PyType_Ready(&PycairoImageSurface_Type) < 0)
     return NULL;


### PR DESCRIPTION
PyType_Ready() expects subclasses to be initialized after base classes. Since ScriptSurface inherits from Surface, Surface must be initialized first.

This causes a segfault in pypy3.10, and the fix was suggested here:

https://foss.heptapod.net/pypy/pypy/-/issues/4017#note_332375

This fixes the seg fault for me.