### PR TITLE
Port from setuptools to meson-python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,10 +155,16 @@ jobs:
         run: |
           python .ci/download-cairo-win32.py
 
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1.13.0
+        with:
+          arch : ${{ matrix.architecture }}
+
       - name: Build
         env:
           PKG_CONFIG: ${{ github.workspace }}/cairo-prebuild/bin/pkgconf.exe
           PKG_CONFIG_PATH: ${{ github.workspace }}/cairo-prebuild/lib/pkgconfig
+          CFLAGS: "-DCAIRO_WIN32_STATIC_BUILD=1"
         run: |
           python -m pip install --upgrade pip
           if (-not $?) { exit 1 }

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,10 +17,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade build
 
       - name: Build sdist
-        run: python setup.py sdist
+        run: python -m build --sdist
 
       - uses: actions/upload-artifact@v4
         with:
@@ -37,20 +37,24 @@ jobs:
           - os: windows-2019
             platform_id: win_amd64
             cairo_plat: x64
+            msvc_arch: x64
           - os: windows-2019
             platform_id: win32
             cairo_plat: x86
-          - os: windows-2019
-            platform_id: win_arm64
-            cairo_plat: arm64
+            msvc_arch: x86
 
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1.13.0
+        with:
+          arch : ${{ matrix.msvc_arch }}
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16
         env:
-          CIBW_ARCHS_WINDOWS: "x86 ARM64 AMD64"
+          CFLAGS: "-DCAIRO_WIN32_STATIC_BUILD=1"
           CIBW_BEFORE_BUILD: "python {package}/.ci/download-cairo-win32.py ${{ matrix.cairo_plat }}"
           CIBW_BUILD: cp39-${{ matrix.platform_id }} cp310-${{ matrix.platform_id }} cp311-${{ matrix.platform_id }} cp312-${{ matrix.platform_id }}
           CIBW_TEST_REQUIRES: pytest==7.4.4 hypothesis==6.98.3 attrs==23.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ coverage = "^7.2.3"
 sphinx-autobuild = "^2021.3.14"
 setuptools = "^69.0.3"
 
+[tool.meson-python.args]
+setup = ["-Dwheel=true", "-Dtests=false"]
+
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+build-backend = 'mesonpy'
+requires = ['meson-python >= 0.12.1']


### PR DESCRIPTION
This is currently blocked on meson-python not supporting cross compiling for arm64 on Windows.

Cross compiling is currently a hack between setuptools and cibuildwheel and not part of any spec, so it's not clear where this should be fixed.

We could drop arm64 wheels to unblock this.