### PR TITLE
Stop using _PyUnicode_AsString() to fix the build with Python 3.13.0a1

### DIFF
--- a/cairo/enums.c
+++ b/cairo/enums.c
@@ -126,7 +126,7 @@ int_enum_get_name(PyObject *obj) {
         return NULL;
 
     return PyUnicode_FromFormat ("%s.%s", Py_TYPE(obj)->tp_name,
-                                 _PyUnicode_AsString(name_obj));
+                                 PyUnicode_AsUTF8(name_obj));
 }
 
 static PyObject *


### PR DESCRIPTION
It was removed upstream in https://github.com/python/cpython/pull/107021

Fixes #343