### PR TITLE
Avoid invalid PyBUF_READ flag in PyObject_GetBuffer()

### DIFF
--- a/cairo/surface.c
+++ b/cairo/surface.c
@@ -484,7 +484,7 @@ surface_set_mime_data (PycairoSurface *o, PyObject *args) {
     return NULL;
   }
 
-  res = PyObject_GetBuffer (obj, view, PyBUF_READ);
+  res = PyObject_GetBuffer (obj, view, PyBUF_SIMPLE);
   if (res == -1) {
       PyMem_Free (view);
       return NULL;


### PR DESCRIPTION
Since Python 3.13, the flag is no longer allowed.

See https://github.com/python/cpython/pull/114707

Fixes https://github.com/pygobject/pycairo/issues/365