### PR TITLE
CI: port Ubuntu tests away from setup.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,40 +88,29 @@ jobs:
       run: |
         sudo apt-get update -q
         sudo apt-get install -y libcairo2-dev ninja-build
-        python -m pip install --upgrade setuptools
-        python -m pip install --upgrade pytest flake8 coverage hypothesis wheel poetry meson
-        python -m pip install --upgrade pygame || true
-
-    - name: Build & Test with setuptools
-      run: |
-        export CFLAGS="-Werror -coverage"
-        PYTHONDEVMODE=1 python -m coverage run --branch setup.py test
-        python -m coverage xml -i
-        python setup.py sdist
-        python setup.py bdist_wheel
-        python setup.py install --root="$(pwd)"/_root_abs
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-
-    - name: Build & Install with pip
-      run: |
-        git clean -xfdf
-        python -m pip install .
+        pipx install poetry
+        pipx install meson
+        poetry install
+        poetry run pip install --upgrade pygame || true
+        poetry run pip install --upgrade numpy || true
 
     - name: Build & Test with meson
       run: |
-        git clean -xfdf
-        meson --werror _build
-        meson compile -C _build
-        meson test -v -C _build
+        poetry run meson --werror _build
+        poetry run meson compile -C _build
+        poetry run meson test -v -C _build
+        rm -Rf _build
 
     - name: Build & Test with poetry
-      if: ${{ matrix.python-version != 'pypy-3.10' }}
       run: |
-        git clean -xfdf
-        poetry install
-        poetry run python setup.py test
+        export CFLAGS="-Werror -coverage"
+        export PYTHONDEVMODE=1
+        poetry run pip install -e .
+        poetry run coverage run --branch -m pytest
+        poetry run coverage xml -i
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
 
     - name: Run linters
       if: ${{ matrix.python-version != 'pypy-3.10' }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 ignore=E402,E741
 builtins=buffer,unichr
 max-line-length = 100
+exclude = build
 
 [coverage:run]
 include=

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -6,7 +6,7 @@ import cairo
 
 def test_typing():
     mod = types.ModuleType("cairo")
-    stub = os.path.join(cairo.__path__[0], "__init__.pyi")
+    stub = os.path.join(os.path.dirname(cairo.__file__), "__init__.pyi")
     with open(stub, encoding="utf-8") as h:
         code = compile(h.read(), stub, "exec")
         exec(code, mod.__dict__)


### PR DESCRIPTION
* Run everything via pip/poetry/meson instead.
* meson-python creates a "build" dir by default, so skip that for flake8
* In editable mode `cairo.__path__` doesn't point to the source dir, so use `__file__` instead