### PR TITLE
CI: disable build isolation and bump meson-python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           export CFLAGS="-Werror -coverage"
           export PYTHONDEVMODE=1
-          poetry run pip install -e .
+          poetry run pip install --no-build-isolation -e .
           poetry run coverage run --branch -m pytest
           poetry run coverage xml -i
 
@@ -99,7 +99,7 @@ jobs:
       run: |
         export CFLAGS="-Werror -coverage"
         export PYTHONDEVMODE=1
-        poetry run pip install -e .
+        poetry run pip install --no-build-isolation -e .
         poetry run coverage run --branch -m pytest
         poetry run coverage xml -i
 
@@ -176,7 +176,7 @@ jobs:
           CFLAGS: "-DCAIRO_WIN32_STATIC_BUILD=1"
           PYTHONDEVMODE: 1
         run: |
-          poetry run pip install -e .
+          poetry run pip install --no-build-isolation -e .
           poetry run coverage run --branch -m pytest
           if (-not $?) { exit 1 }
           poetry run coverage xml -i
@@ -207,7 +207,7 @@ jobs:
         run: |
           export CFLAGS="-Werror -coverage"
           export PYTHONDEVMODE=1
-          poetry run pip install -e .
+          poetry run pip install --no-build-isolation -e .
           poetry run coverage run --branch -m pytest
           poetry run coverage xml -i
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ sphinx-rtd-theme = "^2.0.0"
 coverage = {extras = ["toml"], version = "^7.2.3"}
 sphinx-autobuild = "^2021.3.14"
 setuptools = "^69.0.3"
+meson-python = ">= 0.16.0"
 
 [tool.coverage.run]
 include = [
@@ -66,4 +67,4 @@ setup = ["-Dwheel=true", "-Dtests=false"]
 
 [build-system]
 build-backend = 'mesonpy'
-requires = ['meson-python >= 0.12.1']
+requires = ['meson-python >= 0.16.0']


### PR DESCRIPTION
Turns out we already depend on a newer version, as building with 0.12 fails here due some config keys being not optional there, so bump it.

To make it easier to test certain build tool versions add meson-python as a dev dependency (matching the build-system version requirement, so we are testing the same thing) and in CI build without build isolation, so we are using meson-python as installed by poetry.