### PR TITLE
Fix compatibility with Python 3.14.0a1

### DIFF
--- a/cairo/__init__.pyi
+++ b/cairo/__init__.pyi
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import (Any, BinaryIO, ByteString, Callable, Generic, List, Optional,
+from typing import (Any, BinaryIO, Callable, Generic, List, Optional,
                     Sequence, Text, Tuple, TypeVar, Union)
 
 del annotations
@@ -1975,6 +1975,7 @@ class Device:
     def __enter__(self: _SomeDevice) -> _SomeDevice: ...
     __exit__: Any = ...
 
+ByteString = Union[bytes, bytearray, memoryview]
 _PathLike = Union[Text, ByteString]
 _FileLike = BinaryIO
 _SomeSurface = TypeVar("_SomeSurface", bound="Surface")


### PR DESCRIPTION
typing.ByteString has been removed, port to the recommended, backwards comptible alternative.

Documentation (see: https://docs.python.org/3/library/typing.html#typing.ByteString): Prefer collections.abc.Buffer, or a union like bytes | bytearray | memoryview.

Solves #388 