### PR TITLE
tests: fix hypothesis tests when running in CI

### DIFF
--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -9,20 +9,10 @@ import pytest
 import cairo
 
 pytest.importorskip("hypothesis")
-from hypothesis import given, strategies, assume, settings
+from hypothesis import given, strategies, assume
 from hypothesis.strategies import floats, integers
 
 from .hypothesis_fspaths import fspaths
-
-
-if "CI" in os.environ:
-    # CI can be slow, so be patient
-    # Also we can run more tests there
-    settings.register_profile(
-        "ci",
-        deadline=settings.default.deadline * 10,
-        max_examples=settings.default.max_examples * 5)
-    settings.load_profile("ci")
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
hypothesis broke API in https://github.com/HypothesisWorks/hypothesis/pull/4152 by changing the documented settings defaults to a different type (it's a good change though)

Since the upstream change is trying to make good defaults for CI remove our CI specific settings adjustments and just use the new defaults.