### PR TITLE
ImageSurface.get_data: raise in case the surface is finished + more docs

### DIFF
--- a/cairo/__init__.pyi
+++ b/cairo/__init__.pyi
@@ -2466,11 +2466,21 @@ class ImageSurface(Surface):
 
     def get_data(self) -> memoryview:
         """
-        :returns: a Python buffer object for the data of the *ImageSurface*, for
-            direct inspection or modification. On Python 3 a memoryview object is
-            returned.
+        :returns: a Python memoryview object for the data of the *ImageSurface*,
+            for direct inspection or modification.
+        :raises cairo.Error: In case the surface is finished.
+
+        Get a :class:`memoryview` object for the data of the *ImageSurface*, for
+        direct inspection or modification.
+
+        A call to :meth:`Surface.flush` is required before accessing the pixel
+        data to ensure that all pending drawing operations are finished. A call
+        to :meth:`Surface.mark_dirty` is required after the data is modified.
 
         .. versionadded:: 1.2
+
+        .. versionchanged:: 1.28.0
+            Will raise in case the surface is finished.
         """
 
     def get_format(self) -> Format:

--- a/cairo/surface.c
+++ b/cairo/surface.c
@@ -999,6 +999,18 @@ image_surface_get_data (PycairoImageSurface *o, PyObject *ignored) {
   unsigned char * buffer;
 
   surface = o->surface;
+
+  // We need to figure out if the surface is finished or not to see
+  // if the buffer is still valid.
+  // https://gitlab.freedesktop.org/cairo/cairo/-/issues/406
+  // https://github.com/gtk-rs/cairo/issues/323
+  cairo_t *ctx = cairo_create (surface);
+  cairo_status_t status = cairo_status (ctx);
+  cairo_destroy (ctx);
+  if (Pycairo_Check_Status (status)) {
+    return NULL;
+  }
+
   buffer = cairo_image_surface_get_data (surface);
   if (buffer == NULL) {
     Py_RETURN_NONE;

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -744,6 +744,39 @@ def test_image_surface_create_for_data():
         cairo.ImageSurface.create_for_data(buf, format_, 3, object())
 
 
+def test_image_surface_get_data_finished():
+    surface = cairo.ImageSurface(cairo.Format.ARGB32, 30, 30)
+    surface.finish()
+    with pytest.raises(cairo.Error) as excinfo:
+        surface.get_data()
+    assert excinfo.value.status == cairo.Status.SURFACE_FINISHED
+
+
+def test_image_surface_buffer_get_data_finished():
+    width, height = 6, 4
+    buffer = bytearray(width * height * 4)
+    surface = cairo.ImageSurface.create_for_data(
+        buffer, cairo.FORMAT_ARGB32, width, height, width * 4
+    )
+    surface.finish()
+    with pytest.raises(cairo.Error) as excinfo:
+        surface.get_data()
+    assert excinfo.value.status == cairo.Status.SURFACE_FINISHED
+
+
+def test_image_surface_png_get_data_finished():
+    surface = cairo.ImageSurface(cairo.Format.ARGB32, 30, 30)
+    fileobj = io.BytesIO()
+    surface.write_to_png(fileobj)
+    surface.finish()
+    fileobj.seek(0)
+    surface = cairo.ImageSurface.create_from_png(fileobj)
+    surface.finish()
+    with pytest.raises(cairo.Error) as excinfo:
+        surface.get_data()
+    assert excinfo.value.status == cairo.Status.SURFACE_FINISHED
+
+
 def test_image_surface_stride_for_width():
     v = cairo.ImageSurface.format_stride_for_width(cairo.Format.ARGB32, 10)
     assert v == 40


### PR DESCRIPTION
cairo_image_surface_get_data() is documented to return NULL in case the
surface is finished, but that is not the case. It just returns the potentially
freed pointer.

To avoid this being used raise if the surface is already finished. Since there
is no way to check if a surface is finished directly create a dummy context
and query its status instead.

This is potentially a breaking change, there are three cases when called
after finish():

* In the common case of a normal image surface the returned data was
  freed and potentially garbage.
* In case the image surface was sourced from some external buffer
  the returned data was still valid when created in Python,
  though there are plans to change that:
  https://github.com/pygobject/pycairo/issues/392
  When created externally the data is potentially garbage.
* In case the image was from a png it really returned None for
  some reason, though we never documented that case.

Also while at it, copy more from the upstream docs regarding flush() and
mark_dirty().