### PR TITLE
stubs: fix _PathLike types including os.PathLike

### DIFF
--- a/cairo/__init__.pyi
+++ b/cairo/__init__.pyi
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import (Any, BinaryIO, Callable, Generic, List, Optional,
                     Sequence, Text, Tuple, TypeVar, Union)
 
@@ -1975,8 +1976,7 @@ class Device:
     def __enter__(self: _SomeDevice) -> _SomeDevice: ...
     __exit__: Any = ...
 
-ByteString = Union[bytes, bytearray, memoryview]
-_PathLike = Union[Text, ByteString]
+_PathLike = Union[Text, bytes, os.PathLike[Any]]
 _FileLike = BinaryIO
 _SomeSurface = TypeVar("_SomeSurface", bound="Surface")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,10 @@ ignore_errors = true
 module = "tests.*"
 ignore_errors = true
 
+[[tool.mypy.overrides]]
+module = "tests.test_stubs"
+ignore_errors = false
+
 [tool.meson-python.args]
 setup = ["-Dwheel=true", "-Dtests=false"]
 

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -1,0 +1,8 @@
+import typing
+import cairo
+import pathlib
+
+if typing.TYPE_CHECKING:
+    cairo.PSSurface(b"", 0, 0)
+    cairo.PSSurface("", 0, 0)
+    cairo.PSSurface(pathlib.Path(""), 0, 0)


### PR DESCRIPTION
All pycairo functions take str, bytes and os.PathLike. bytearray, memoryview doesn't work, and os.PathLike was missing.