### PR TITLE
mypy: enable some type checking for tests

### DIFF
--- a/cairo/__init__.pyi
+++ b/cairo/__init__.pyi
@@ -2421,7 +2421,7 @@ class Surface:
         .. versionadded:: 1.2
         """
 
-    def set_mime_data(self, mime_type: str, data: bytes) -> None:
+    def set_mime_data(self, mime_type: str, data: Optional[bytes]) -> None:
         """
         :param mime_type: the MIME type of the image data
             (:ref:`constants_MIME_TYPE`)
@@ -4674,7 +4674,7 @@ class PDFSurface(Surface):
 
     def __init__(
         self,
-        fobj: Union[_PathLike, _FileLike],
+        fobj: Union[_PathLike, _FileLike, None],
         width_in_points: float,
         height_in_points: float,
     ) -> None:
@@ -4829,7 +4829,7 @@ class PSSurface(Surface):
 
     def __init__(
         self,
-        fobj: Union[_FileLike, _PathLike],
+        fobj: Union[_FileLike, _PathLike, None],
         width_in_points: float,
         height_in_points: float,
     ) -> None:
@@ -5061,7 +5061,7 @@ class SVGSurface(Surface):
 
     def __init__(
         self,
-        fobj: "Union[_PathLike, _FileLike]",
+        fobj: Union[_PathLike, _FileLike, None],
         width_in_points: float,
         height_in_points: float,
     ) -> None:
@@ -5333,7 +5333,7 @@ class RecordingSurface(Surface):
     .. versionadded:: 1.11.0
     """
 
-    def __init__(self, content: Content, rectangle: Rectangle) -> None:
+    def __init__(self, content: Content, rectangle: Optional[Rectangle]) -> None:
         """
         :param content: the content for the new  surface
         :param rectangle: or None to record unbounded operations.
@@ -5384,7 +5384,7 @@ class Region:
     .. versionadded:: 1.11.0
     """
 
-    def __init__(self, rectangle: Union[RectangleInt, List[RectangleInt]]) -> None:
+    def __init__(self, rectangle: Union[RectangleInt, Sequence[RectangleInt]] = []) -> None:
         """
         :param rectangle_int: a rectangle or a list of rectangle
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,12 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = "tests.*"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = "tests.test_stubs"
-ignore_errors = false
+disallow_untyped_defs = false
+check_untyped_defs = false
+disallow_any_expr = false
+disallow_any_generics = false
+disallow_any_decorated = false
+disallow_untyped_calls = false
 
 [tool.meson-python.args]
 setup = ["-Dwheel=true", "-Dtests=false"]

--- a/tests/cmod.pyi
+++ b/tests/cmod.pyi
@@ -1,0 +1,5 @@
+import cairo
+
+
+def create_image_surface() -> cairo.ImageSurface:
+    ...

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,6 @@
 test_sources = [
   '__init__.py',
+  'cmod.pyi',
   'test_api.py',
   'test_cmod.py',
   'test_context.py',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,14 +11,14 @@ import cairo
 import pytest
 
 
-def test_get_include():
+def test_get_include() -> None:
     include = cairo.get_include()
     assert isinstance(include, str)
     assert os.path.exists(include)
     assert os.path.isdir(include)
 
 
-def test_version():
+def test_version() -> None:
     cairo.cairo_version()
     cairo.cairo_version_string()
 
@@ -30,7 +30,7 @@ def test_version():
         ver_tuple
 
 
-def test_show_unicode_text():
+def test_show_unicode_text() -> None:
     width, height = 300, 300
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
     ctx = cairo.Context(surface)
@@ -45,7 +45,7 @@ def test_show_unicode_text():
     ctx.show_text("ēxāmple.")
 
 
-def test_unicode_filenames():
+def test_unicode_filenames() -> None:
     # FIXME: cairo does not support wchar on Windows and byte support is
     # missing under Python 3
 
@@ -62,7 +62,7 @@ def test_unicode_filenames():
         shutil.rmtree(dirname)
 
 
-def test_surface_has_show_text_glyphs():
+def test_surface_has_show_text_glyphs() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 100, 100)
     assert not surface.has_show_text_glyphs()
     surface.finish()
@@ -70,7 +70,7 @@ def test_surface_has_show_text_glyphs():
         surface.has_show_text_glyphs()
 
 
-def test_context():
+def test_context() -> None:
     f, w, h = cairo.FORMAT_ARGB32, 100, 100
     s = cairo.ImageSurface(f, w, h)
     ctx = cairo.Context(s)
@@ -79,14 +79,14 @@ def test_context():
     ctx.paint()
 
 
-def test_surface():
+def test_surface() -> None:
     # TypeError: The Surface type cannot be instantiated
     with pytest.raises(TypeError):
         cairo.Surface()
 
-    f, w, h = cairo.FORMAT_ARGB32, 100, 100
-    s = cairo.ImageSurface(f, w, h)
-    assert s.get_format() == f
+    format, w, h = cairo.FORMAT_ARGB32, 100, 100
+    s = cairo.ImageSurface(format, w, h)
+    assert s.get_format() == format
     assert s.get_width() == w
     assert s.get_height() == h
 
@@ -96,14 +96,15 @@ def test_surface():
     with tempfile.TemporaryFile(mode='w+b') as f:
         cairo.PSSurface(f, 100, 100)
 
-    s = cairo.RecordingSurface(cairo.CONTENT_COLOR, None)
-    s = cairo.RecordingSurface(cairo.CONTENT_COLOR, (1, 1, 10, 10))
+    cairo.RecordingSurface(cairo.CONTENT_COLOR, None)
+    cairo.RecordingSurface(cairo.CONTENT_COLOR, cairo.Rectangle(1, 1, 10, 10))
+    cairo.RecordingSurface(cairo.CONTENT_COLOR, (1, 1, 10, 10))  # type: ignore
 
     with tempfile.TemporaryFile(mode='w+b') as f:
         cairo.SVGSurface(f, 100, 100)
 
 
-def test_surface_destroy_before_context():
+def test_surface_destroy_before_context() -> None:
     for kind in [cairo.PDFSurface, cairo.PSSurface]:
         surface = kind(io.BytesIO(), 1, 1)
         ctx = cairo.Context(surface)
@@ -111,7 +112,7 @@ def test_surface_destroy_before_context():
         ctx.paint()
 
 
-def test_surface_destroy_before_surface_pattern():
+def test_surface_destroy_before_surface_pattern() -> None:
     surface = cairo.PDFSurface(io.BytesIO(), 1, 1)
     pattern = cairo.SurfacePattern(surface)
     del surface
@@ -119,19 +120,19 @@ def test_surface_destroy_before_surface_pattern():
     ctx.paint()
 
 
-def test_recording_surface_get_extents():
+def test_recording_surface_get_extents() -> None:
     surface = cairo.RecordingSurface(cairo.CONTENT_COLOR, None)
     assert surface.get_extents() is None
 
-    surface = cairo.RecordingSurface(cairo.CONTENT_COLOR, (1, 2, 3, 4))
+    surface = cairo.RecordingSurface(cairo.CONTENT_COLOR, (1, 2, 3, 4))  # type: ignore
     assert surface.get_extents() == (1, 2, 3, 4)
 
-    surface = cairo.RecordingSurface(cairo.CONTENT_COLOR, (1, 2, 3, 4))
+    surface = cairo.RecordingSurface(cairo.CONTENT_COLOR, (1, 2, 3, 4))  # type: ignore
     surface.finish()
     assert surface.get_extents() == (1, 2, 3, 4)
 
 
-def test_image_surface_get_data():
+def test_image_surface_get_data() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 3, 3)
     ctx = cairo.Context(surface)
     ctx.paint()
@@ -158,15 +159,13 @@ def test_surface_file_obj_error():
             if data:
                 raise OSError
 
-    cairo.PDFSurface(Fail(), 100, 100)
-    cairo.PSSurface(Fail(), 100, 100)
+    # We don't have these annotated to accept any object with write()
+    # method, so we need to ignore the type error.
+    cairo.PDFSurface(Fail(), 100, 100)  # type: ignore
+    cairo.PSSurface(Fail(), 100, 100)  # type: ignore
 
 
-def test_text():
-    pass
-
-
-def test_region():
+def test_region() -> None:
     a = cairo.Region()
     assert a.is_empty() is True
     assert a.num_rectangles() == 0
@@ -213,14 +212,14 @@ def test_region():
         cairo.RectangleInt(1, 14, 8, 1),
     ])
 
-    d = cairo.Region(d)
+    r = cairo.Region(d)
     c = cairo.Region((b, e))
-    c.subtract(d)
+    c.subtract(r)
     assert c.num_rectangles() == 2
     assert c.get_rectangle(0) == cairo.RectangleInt(1, 13, 10, 1)
 
     c = cairo.Region((b, e))
-    c.union(d)
+    c.union(r)
     assert c.num_rectangles() == 2
     assert c == cairo.Region([
         cairo.RectangleInt(1, 1, 10, 13),
@@ -228,7 +227,7 @@ def test_region():
     ])
 
     c = cairo.Region((b, e))
-    c.xor(d)
+    c.xor(r)
     assert c.num_rectangles() == 3
     assert c == cairo.Region([
         cairo.RectangleInt(1, 1, 10, 1),
@@ -237,7 +236,7 @@ def test_region():
     ])
 
 
-def test_constants():
+def test_constants() -> None:
     assert cairo.REGION_OVERLAP_IN == 0
     assert cairo.REGION_OVERLAP_OUT == 1
     assert cairo.REGION_OVERLAP_PART == 2
@@ -272,7 +271,7 @@ def test_constants():
 
 
 @pytest.mark.skipif(not hasattr(sys, "getrefcount"), reason="PyPy")
-def test_surface_get_set_mime_data_references():
+def test_surface_get_set_mime_data_references() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_RGB24, 1, 1)
     v = memoryview(b"bla")
     x = v[:1]
@@ -295,7 +294,7 @@ def test_surface_get_set_mime_data_references():
 
 @pytest.mark.skipif(
     sysconfig.get_platform().startswith("win"), reason="msvc fixme")
-def test_surface_mime_data_for_pdf():
+def test_surface_mime_data_for_pdf() -> None:
     jpeg_bytes = zlib.decompress(base64.b64decode(
         b'eJz7f+P/AwYBLzdPNwZGRkYGDyBk+H+bwRnEowj8P8TAzcHACDJHkOH/EQYRIBsV'
         b'cP6/xcDBCBJlrLcHqRBAV8EAVcHIylSPVwGbPQEFjPaK9XDrBAipBSq4CQB9jiS0'

--- a/tests/test_cmod.py
+++ b/tests/test_cmod.py
@@ -7,6 +7,6 @@ except ImportError:
     pytest.skip("cmod not built", allow_module_level=True)
 
 
-def test_foo():
+def test_foo() -> None:
     surface = cmod.create_image_surface()
     assert isinstance(surface, cairo.ImageSurface)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -11,43 +11,43 @@ def context():
 
 @pytest.mark.skipif(not hasattr(cairo.Context, "tag_begin"),
                     reason="too old cairo")
-def test_tags(context):
+def test_tags(context: cairo.Context) -> None:
     context.tag_begin("foo", "bar=quux")
     context.tag_end("foo")
 
 
-def test_cmp_hash(context):
+def test_cmp_hash(context: cairo.Context) -> None:
     other = cairo.Context(context.get_target())
     assert context != other
     hash(context)
 
 
-def test_get_antialias(context):
+def test_get_antialias(context: cairo.Context) -> None:
     assert context.get_antialias() == cairo.Antialias.DEFAULT
     assert isinstance(context.get_antialias(), cairo.Antialias)
 
 
-def test_get_fill_rule(context):
+def test_get_fill_rule(context: cairo.Context) -> None:
     assert context.get_fill_rule() == cairo.FillRule.WINDING
     assert isinstance(context.get_fill_rule(), cairo.FillRule)
 
 
-def test_get_line_cap(context):
+def test_get_line_cap(context: cairo.Context) -> None:
     assert context.get_line_cap() == cairo.LineCap.BUTT
     assert isinstance(context.get_line_cap(), cairo.LineCap)
 
 
-def test_get_line_join(context):
+def test_get_line_join(context: cairo.Context) -> None:
     assert context.get_line_join() == cairo.LineJoin.MITER
     assert isinstance(context.get_line_join(), cairo.LineJoin)
 
 
-def test_get_operator(context):
+def test_get_operator(context: cairo.Context) -> None:
     assert context.get_operator() == cairo.Operator.OVER
     assert isinstance(context.get_operator(), cairo.Operator)
 
 
-def test_get_set_operator_limits(context):
+def test_get_set_operator_limits(context: cairo.Context) -> None:
     max_int = 2 ** (ctypes.sizeof(ctypes.c_int()) * 8 - 1) - 1
     min_int = -max_int - 1
 
@@ -62,7 +62,7 @@ def test_get_set_operator_limits(context):
         assert context.get_operator() == orig
 
 
-def test_show_text_glyphs():
+def test_show_text_glyphs() -> None:
     surface = cairo.PDFSurface(None, 300, 300)
     context = cairo.Context(surface)
     context.scale(300, 300)
@@ -71,36 +71,40 @@ def test_show_text_glyphs():
     context.set_font_size(0.08)
     context.set_line_width(0.09)
     sf = context.get_scaled_font()
-    glyphs, clusters, flags = sf.text_to_glyphs(0.5, 0.5, "foobar")
+    res = sf.text_to_glyphs(0.5, 0.5, "foobar")
+    assert isinstance(res, tuple)
+    glyphs, clusters, flags = res
     context.show_text_glyphs("foobar", glyphs, clusters, flags)
 
-    glyphs, clusters, flags = sf.text_to_glyphs(0.5, 0.5, "")
+    res = sf.text_to_glyphs(0.5, 0.5, "")
+    assert isinstance(res, tuple)
+    glyphs, clusters, flags = res
     context.show_text_glyphs("", glyphs, clusters, flags)
 
     with pytest.raises(TypeError):
-        context.show_text_glyphs(object(), glyphs, clusters, flags)
+        context.show_text_glyphs(object(), glyphs, clusters, flags)  # type: ignore
 
     with pytest.raises(TypeError):
-        context.show_text_glyphs("", [object()], clusters, flags)
+        context.show_text_glyphs("", [object()], clusters, flags)  # type: ignore
 
     with pytest.raises(TypeError):
-        context.show_text_glyphs("", object(), clusters, flags)
+        context.show_text_glyphs("", object(), clusters, flags)  # type: ignore
 
     with pytest.raises(TypeError):
-        context.show_text_glyphs("", glyphs, [object()], flags)
+        context.show_text_glyphs("", glyphs, [object()], flags)  # type: ignore
 
     with pytest.raises(TypeError):
-        context.show_text_glyphs("", glyphs, object(), flags)
+        context.show_text_glyphs("", glyphs, object(), flags)  # type: ignore
 
 
-def test_append_path(context):
+def test_append_path(context: cairo.Context) -> None:
     context.line_to(1, 2)
     p = context.copy_path()
     context.new_path()
     context.append_path(p)
     assert str(context.copy_path()) == str(p)
     with pytest.raises(TypeError):
-        context.append_path(object())
+        context.append_path(object())  # type: ignore
 
 
 def test_arc(context):
@@ -108,7 +112,7 @@ def test_arc(context):
     context.arc(0, 0, 0, 0, 0)
     assert list(context.copy_path())
     with pytest.raises(TypeError):
-        context.arc(object())
+        context.arc(object())  # type: ignore
 
 
 def test_arc_negative(context):
@@ -116,14 +120,14 @@ def test_arc_negative(context):
     context.arc_negative(0, 0, 0, 0, 0)
     assert list(context.copy_path())
     with pytest.raises(TypeError):
-        context.arc_negative(object())
+        context.arc_negative(object())  # type: ignore
 
 
-def test_clip_extents(context):
+def test_clip_extents(context: cairo.Context) -> None:
     assert context.clip_extents() == (0.0, 0.0, 42.0, 42.0)
 
 
-def test_in_clip():
+def test_in_clip() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 100, 100)
     context = cairo.Context(surface)
     assert context.in_clip(50, 50)
@@ -133,22 +137,22 @@ def test_in_clip():
     assert context.in_clip(50, 50)
 
     with pytest.raises(TypeError):
-        context.in_clip(None, None)
+        context.in_clip(None, None)  # type: ignore
 
 
-def test_device_to_user(context):
+def test_device_to_user(context: cairo.Context) -> None:
     assert context.device_to_user(0, 0) == (0, 0)
     with pytest.raises(TypeError):
-        context.device_to_user(None, None)
+        context.device_to_user(None, None)  # type: ignore
 
 
-def test_device_to_user_distance(context):
+def test_device_to_user_distance(context: cairo.Context) -> None:
     assert context.device_to_user_distance(0, 0) == (0, 0)
     with pytest.raises(TypeError):
-        context.device_to_user_distance(None, None)
+        context.device_to_user_distance(None, None)  # type: ignore
 
 
-def test_fill_extents(context):
+def test_fill_extents(context: cairo.Context) -> None:
     context.line_to(1, 1)
     context.line_to(1, 0)
     context.line_to(0, 0)
@@ -157,12 +161,12 @@ def test_fill_extents(context):
     assert context.fill_extents() == (0, 0, 1, 1)
 
 
-def test_curve_to(context):
+def test_curve_to(context: cairo.Context) -> None:
     with pytest.raises(TypeError):
-        context.curve_to(1, 2, 3, 4, 5, object())
+        context.curve_to(1, 2, 3, 4, 5, object())  # type: ignore
 
 
-def test_set_get_dash(context):
+def test_set_get_dash(context: cairo.Context) -> None:
     assert context.get_dash() == ((), 0)
     assert context.get_dash_count() == 0
 
@@ -174,39 +178,39 @@ def test_set_get_dash(context):
     assert context.get_dash() == ((1.0,), 1.25)
 
     with pytest.raises(TypeError):
-        context.set_dash()
+        context.set_dash()  # type: ignore
 
     with pytest.raises(TypeError):
-        context.set_dash(1, 10)
+        context.set_dash(1, 10)  # type: ignore
 
     with pytest.raises(TypeError):
-        context.set_dash([object()], 1)
+        context.set_dash([object()], 1)  # type: ignore
 
 
-def test_glyph_extents(context):
+def test_glyph_extents(context: cairo.Context) -> None:
     with pytest.raises(TypeError):
-        context.glyph_extents(None)
+        context.glyph_extents(None)  # type: ignore
     with pytest.raises(TypeError):
-        context.glyph_extents()
+        context.glyph_extents()  # type: ignore
 
 
-def test_glyph_path(context):
+def test_glyph_path(context: cairo.Context) -> None:
     with pytest.raises(TypeError):
-        context.glyph_path(None)
+        context.glyph_path(None)  # type: ignore
     with pytest.raises(TypeError):
-        context.glyph_path()
+        context.glyph_path()  # type: ignore
 
 
-def test_in_stroke(context):
+def test_in_stroke(context: cairo.Context) -> None:
     context.line_to(0, 0)
     context.line_to(1, 1)
     assert context.in_stroke(0, 0)
     assert not context.in_stroke(0, 2)
     with pytest.raises(TypeError):
-        context.in_stroke(object(), 0)
+        context.in_stroke(object(), 0)  # type: ignore
 
 
-def test_current_point(context):
+def test_current_point(context: cairo.Context) -> None:
     assert not context.has_current_point()
     assert context.get_current_point() == (0, 0)
     context.move_to(10, 10)
@@ -214,37 +218,37 @@ def test_current_point(context):
     assert context.get_current_point() == (10, 10)
 
 
-def test_in_fill(context):
+def test_in_fill(context: cairo.Context) -> None:
     assert not context.in_fill(0.1, 0.1)
     with pytest.raises(TypeError):
-        context.in_fill(0.1, object())
+        context.in_fill(0.1, object())  # type: ignore
 
 
-def test_line_to(context):
+def test_line_to(context: cairo.Context) -> None:
     with pytest.raises(TypeError):
-        context.line_to(0.1, object())
+        context.line_to(0.1, object())  # type: ignore
 
 
-def test_mask(context):
+def test_mask(context: cairo.Context) -> None:
     pattern = cairo.SolidPattern(0, 0, 0)
     context.mask(pattern)
     with pytest.raises(TypeError):
-        context.mask(object())
+        context.mask(object())  # type: ignore
 
 
-def test_mask_surface(context):
+def test_mask_surface(context: cairo.Context) -> None:
     context.mask_surface(context.get_target(), 0, 0)
     with pytest.raises(TypeError):
-        context.mask_surface(object(), 0, 0)
+        context.mask_surface(object(), 0, 0)  # type: ignore
 
 
-def test_paint_with_alpha(context):
+def test_paint_with_alpha(context: cairo.Context) -> None:
     context.paint_with_alpha(0.5)
     with pytest.raises(TypeError):
-        context.paint_with_alpha(object())
+        context.paint_with_alpha(object())  # type: ignore
 
 
-def test_path_extents(context):
+def test_path_extents(context: cairo.Context) -> None:
     context.line_to(1, 1)
     context.line_to(1, 0)
     context.line_to(0, 0)
@@ -253,7 +257,7 @@ def test_path_extents(context):
     assert context.path_extents() == (0.0, 0.0, 1.0, 1.0)
 
 
-def test_push_pop_group(context):
+def test_push_pop_group(context: cairo.Context) -> None:
     context.push_group()
     context.pop_group()
 
@@ -261,7 +265,7 @@ def test_push_pop_group(context):
     context.pop_group_to_source()
 
     with pytest.raises(TypeError):
-        context.push_group_with_content(object())
+        context.push_group_with_content(object())  # type: ignore
 
     context.push_group_with_content(cairo.Content.COLOR)
     context.pop_group()
@@ -270,79 +274,79 @@ def test_push_pop_group(context):
         context.pop_group()
 
 
-def test_rectangle(context):
+def test_rectangle(context: cairo.Context) -> None:
     context.rectangle(1, 2, 4, 5)
     assert context.path_extents() == (1.0, 2.0, 5.0, 7.0)
     with pytest.raises(TypeError):
-        context.rectangle(1, 2, 3, object())
+        context.rectangle(1, 2, 3, object())  # type: ignore
 
 
-def test_rotate(context):
+def test_rotate(context: cairo.Context) -> None:
     context.rotate(0.3)
     with pytest.raises(TypeError):
-        context.rotate(object())
+        context.rotate(object())  # type: ignore
 
 
-def test_rel_curve_to(context):
+def test_rel_curve_to(context: cairo.Context) -> None:
     context.line_to(0, 0)
     context.rel_curve_to(0, 0, 0, 0, 0, 0)
     with pytest.raises(TypeError):
-        context.rel_curve_to(object(), 0, 0, 0, 0, 0)
+        context.rel_curve_to(object(), 0, 0, 0, 0, 0)  # type: ignore
 
 
-def test_move_to(context):
+def test_move_to(context: cairo.Context) -> None:
     context.move_to(10, 10)
     assert context.get_current_point() == (10, 10)
     with pytest.raises(TypeError):
-        context.move_to(object(), 0)
+        context.move_to(object(), 0)  # type: ignore
 
 
-def test_rel_line_to(context):
+def test_rel_line_to(context: cairo.Context) -> None:
     context.line_to(0, 0)
     context.rel_line_to(1, 1)
     with pytest.raises(TypeError):
-        context.rel_line_to(object(), 0)
+        context.rel_line_to(object(), 0)  # type: ignore
 
 
-def test_rel_move_to(context):
+def test_rel_move_to(context: cairo.Context) -> None:
     context.line_to(0, 0)
     context.rel_move_to(1, 1)
     with pytest.raises(TypeError):
-        context.rel_move_to(object(), 0)
+        context.rel_move_to(object(), 0)  # type: ignore
 
 
-def test_save_restore(context):
+def test_save_restore(context: cairo.Context) -> None:
     context.save()
     context.restore()
 
 
-def test_scale(context):
+def test_scale(context: cairo.Context) -> None:
     context.scale(2, 2)
     with pytest.raises(TypeError):
-        context.scale(object(), 0)
+        context.scale(object(), 0)  # type: ignore
 
 
-def test_select_font_face(context):
+def test_select_font_face(context: cairo.Context) -> None:
     context.select_font_face("")
     with pytest.raises(TypeError):
-        context.select_font_face(None)
+        context.select_font_face(None)  # type: ignore
 
 
-def test_set_antialias(context):
+def test_set_antialias(context: cairo.Context) -> None:
     context.set_antialias(cairo.Antialias.SUBPIXEL)
     assert context.get_antialias() == cairo.Antialias.SUBPIXEL
     with pytest.raises(TypeError):
-        context.set_antialias(object())
+        context.set_antialias(object())  # type: ignore
 
 
-def test_set_fill_rule(context):
+def test_set_fill_rule(context: cairo.Context) -> None:
     context.set_fill_rule(cairo.FillRule.EVEN_ODD)
     assert context.get_fill_rule() == cairo.FillRule.EVEN_ODD
     with pytest.raises(TypeError):
-        context.set_fill_rule(object())
+        context.set_fill_rule(object())  # type: ignore
 
 
-def test_set_font_face(context):
+def test_set_font_face(context: cairo.Context) -> None:
     assert context.get_font_face()
     context.set_font_face(None)
     assert context.get_font_face()
@@ -350,168 +354,173 @@ def test_set_font_face(context):
     context.set_font_face(ff)
     assert context.get_font_face() == ff
     with pytest.raises(TypeError):
-        context.set_font_face(object())
+        context.set_font_face(object())  # type: ignore
 
 
-def test_set_font_matrix(context):
+def test_set_font_matrix(context: cairo.Context) -> None:
     m = cairo.Matrix()
     context.set_font_matrix(m)
     assert context.get_font_matrix() == m
     with pytest.raises(TypeError):
-        context.set_font_matrix(object())
+        context.set_font_matrix(object())  # type: ignore
 
 
-def test_set_line_cap(context):
+def test_set_line_cap(context: cairo.Context) -> None:
     context.set_line_cap(cairo.LineCap.SQUARE)
     assert context.get_line_cap() == cairo.LineCap.SQUARE
     with pytest.raises(TypeError):
-        context.set_line_cap(object())
+        context.set_line_cap(object())  # type: ignore
 
 
-def test_set_line_join(context):
+def test_set_line_join(context: cairo.Context) -> None:
     context.set_line_join(cairo.LineJoin.BEVEL)
     assert context.get_line_join() == cairo.LineJoin.BEVEL
     with pytest.raises(TypeError):
-        context.set_line_join(object())
+        context.set_line_join(object())  # type: ignore
 
 
-def test_set_line_width(context):
+def test_set_line_width(context: cairo.Context) -> None:
     context.set_line_width(42)
     assert context.get_line_width() == 42
     with pytest.raises(TypeError):
-        context.set_line_width(object())
+        context.set_line_width(object())  # type: ignore
 
 
-def test_set_matrix(context):
+def test_set_matrix(context: cairo.Context) -> None:
     m = cairo.Matrix()
     context.set_matrix(m)
     assert context.get_matrix() == m
     with pytest.raises(TypeError):
-        context.set_matrix(object())
+        context.set_matrix(object())  # type: ignore
 
 
-def test_set_miter_limit(context):
+def test_set_miter_limit(context: cairo.Context) -> None:
     context.set_miter_limit(42)
     assert context.get_miter_limit() == 42
     with pytest.raises(TypeError):
-        context.set_miter_limit(object())
+        context.set_miter_limit(object())  # type: ignore
 
 
-def test_set_scaled_font(context):
+def test_set_scaled_font(context: cairo.Context) -> None:
     context.set_scaled_font(context.get_scaled_font())
     with pytest.raises(TypeError):
-        context.set_scaled_font(object())
+        context.set_scaled_font(object())  # type: ignore
 
 
-def test_set_font_options(context):
+def test_set_font_options(context: cairo.Context) -> None:
     context.set_font_options(context.get_font_options())
     with pytest.raises(TypeError):
-        context.set_font_options(object())
+        context.set_font_options(object())  # type: ignore
 
 
-def test_set_font_size(context):
+def test_set_font_size(context: cairo.Context) -> None:
     context.set_font_size(42)
     assert context.get_font_matrix() == cairo.Matrix(42, 0, 0, 42, 0, 0)
     with pytest.raises(TypeError):
-        context.set_font_size(object())
+        context.set_font_size(object())  # type: ignore
 
 
-def test_set_source(context):
+def test_set_source(context: cairo.Context) -> None:
     p = cairo.SolidPattern(0, 0, 0)
     context.set_source(p)
     assert context.get_source() == p
     with pytest.raises(TypeError):
-        context.set_source(object())
+        context.set_source(object())  # type: ignore
 
 
-def test_set_source_rgb(context):
+def test_set_source_rgb(context: cairo.Context) -> None:
     with pytest.raises(TypeError):
-        context.set_source_rgb(1, 1, object())
+        context.set_source_rgb(1, 1, object())  # type: ignore
 
 
-def test_get_source_rgba(context):
+def test_get_source_rgba(context: cairo.Context) -> None:
     context.set_source_rgba(1, 1, 1)
-    assert context.get_source().get_rgba() == (1, 1, 1, 1)
+    source = context.get_source()
+    assert isinstance(source, cairo.SolidPattern)
+    assert source.get_rgba() == (1, 1, 1, 1)
     context.set_source_rgba(1, 1, 1, 0.5)
-    assert context.get_source().get_rgba() == (1, 1, 1, 0.5)
+    source = context.get_source()
+    assert isinstance(source, cairo.SolidPattern)
+    assert source.get_rgba() == (1, 1, 1, 0.5)
     with pytest.raises(TypeError):
-        context.set_source_rgba(1, 1, object())
+        context.set_source_rgba(1, 1, object())  # type: ignore
 
 
-def test_set_source_surface(context):
+def test_set_source_surface(context: cairo.Context) -> None:
     with pytest.raises(TypeError):
-        context.set_source_surface(object())
+        context.set_source_surface(object())  # type: ignore
 
 
-def test_set_tolerance(context):
+def test_set_tolerance(context: cairo.Context) -> None:
     context.set_tolerance(42)
     assert context.get_tolerance() == 42
     with pytest.raises(TypeError):
-        context.set_tolerance(object())
+        context.set_tolerance(object())  # type: ignore
 
 
-def test_show_glyphs(context):
+def test_show_glyphs(context: cairo.Context) -> None:
     with pytest.raises(TypeError):
-        context.show_glyphs()
+        context.show_glyphs()  # type: ignore
 
     with pytest.raises(TypeError):
-        context.show_glyphs(object())
+        context.show_glyphs(object())  # type: ignore
 
-    context.show_glyphs([], 0)
+    # the num_glyphs argument is not annotated
+    context.show_glyphs([], 0)  # type: ignore
 
 
-def test_show_text(context):
+def test_show_text(context: cairo.Context) -> None:
     with pytest.raises(TypeError):
-        context.show_text()
+        context.show_text()  # type: ignore
 
 
-def test_stroke_extents(context):
+def test_stroke_extents(context: cairo.Context) -> None:
     assert context.stroke_extents() == (0.0, 0.0, 0.0, 0.0)
 
 
-def test_text_extents(context):
+def test_text_extents(context: cairo.Context) -> None:
     with pytest.raises(TypeError):
-        context.text_extents()
+        context.text_extents()  # type: ignore
 
 
-def test_text_path(context):
+def test_text_path(context: cairo.Context) -> None:
     context.text_path("foo")
     with pytest.raises(TypeError):
-        context.text_path(object())
+        context.text_path(object())  # type: ignore
 
 
-def test_transform(context):
+def test_transform(context: cairo.Context) -> None:
     context.transform(cairo.Matrix())
     with pytest.raises(TypeError):
-        context.transform(object())
+        context.transform(object())  # type: ignore
 
 
-def test_translate(context):
+def test_translate(context: cairo.Context) -> None:
     context.translate(0.5, 0.5)
     with pytest.raises(TypeError):
-        context.translate(0.5, object())
+        context.translate(0.5, object())  # type: ignore
 
 
-def test_user_to_device(context):
+def test_user_to_device(context: cairo.Context) -> None:
     assert context.user_to_device(0, 0) == (0, 0)
     with pytest.raises(TypeError):
-        context.user_to_device(0, object())
+        context.user_to_device(0, object())  # type: ignore
 
 
-def test_user_to_device_distance(context):
+def test_user_to_device_distance(context: cairo.Context) -> None:
     assert context.user_to_device_distance(0, 0) == (0, 0)
     with pytest.raises(TypeError):
-        context.user_to_device_distance(0, object())
+        context.user_to_device_distance(0, object())  # type: ignore
 
 
-def test_context(context):
+def test_context(context: cairo.Context) -> None:
     with pytest.raises(TypeError):
-        cairo.Context(None)
+        cairo.Context(None)  # type: ignore
 
     assert not context == object()
 
 
-def test_simple(context):
+def test_simple(context: cairo.Context) -> None:
     context.clip_preserve()
     context.copy_page()
     context.copy_path_flat()
@@ -536,7 +545,7 @@ def test_simple(context):
 
 @pytest.mark.skipif(not hasattr(cairo.Context, "set_hairline"),
                     reason="too old cairo")
-def test_hairline(context: cairo.Context):
+def test_hairline(context: cairo.Context) -> None:
     assert not context.get_hairline()
     context.set_hairline(True)
     assert isinstance(context.get_hairline(), bool)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -6,7 +6,7 @@ import cairo
 import pytest
 
 
-def test_context_manager():
+def test_context_manager() -> None:
     f = io.BytesIO()
     with cairo.ScriptDevice(f) as dev:
         dev.acquire()
@@ -17,7 +17,7 @@ def test_context_manager():
     assert excinfo.value.status == cairo.Status.DEVICE_FINISHED
 
 
-def test_cmp_hash():
+def test_cmp_hash() -> None:
     f = io.BytesIO()
     dev = cairo.ScriptDevice(f)
     surface = cairo.ScriptSurface(dev, cairo.Content.COLOR_ALPHA, 42, 10)
@@ -28,41 +28,41 @@ def test_cmp_hash():
     assert dev != object()
 
 
-def test_get_device():
+def test_get_device() -> None:
     surface = cairo.ImageSurface(cairo.Format.ARGB32, 10, 10)
     assert surface.get_device() is None
 
 
-def test_type():
-    assert cairo.Device
+def test_type() -> None:
+    assert hasattr(cairo, "Device")
     with pytest.raises(TypeError):
         cairo.Device()
 
 
-def test_has():
+def test_has() -> None:
     assert hasattr(cairo, "HAS_SCRIPT_SURFACE")
 
 
-def test_script_device():
+def test_script_device() -> None:
     dev = cairo.ScriptDevice(io.BytesIO())
     assert dev
     assert issubclass(cairo.ScriptDevice, cairo.Device)
     assert isinstance(dev, cairo.ScriptDevice)
 
     with pytest.raises(TypeError):
-        cairo.ScriptDevice(None)
+        cairo.ScriptDevice(None)  # type: ignore
 
     with pytest.raises(TypeError):
-        cairo.ScriptDevice()
+        cairo.ScriptDevice()  # type: ignore
 
     with pytest.raises(TypeError):
-        cairo.ScriptDevice(io.StringIO())
+        cairo.ScriptDevice(io.StringIO())  # type: ignore
 
     with pytest.raises((ValueError, TypeError)):
         cairo.ScriptDevice("\x00")
 
 
-def test_script_device_mode():
+def test_script_device_mode() -> None:
     assert hasattr(cairo, "ScriptMode")
     assert cairo.ScriptMode.ASCII != cairo.ScriptMode.BINARY
 
@@ -73,10 +73,10 @@ def test_script_device_mode():
     dev.set_mode(cairo.ScriptMode.BINARY)
     assert dev.get_mode() == cairo.ScriptMode.BINARY
     with pytest.raises(TypeError):
-        dev.set_mode(object())
+        dev.set_mode(object())  # type: ignore
 
 
-def test_script_device_write_comment():
+def test_script_device_write_comment() -> None:
     f = io.BytesIO()
     dev = cairo.ScriptDevice(f)
     dev.write_comment("pycairo foo")
@@ -85,10 +85,10 @@ def test_script_device_write_comment():
     assert b"pycairo foo" in f.getvalue()
     assert b"pycairo bar" in f.getvalue()
     with pytest.raises(TypeError):
-        dev.write_comment(object())
+        dev.write_comment(object())  # type: ignore
 
 
-def test_from_recording_surface():
+def test_from_recording_surface() -> None:
     s = cairo.RecordingSurface(cairo.CONTENT_COLOR, None)
     ctx = cairo.Context(s)
     ctx.paint()
@@ -106,21 +106,21 @@ def test_from_recording_surface():
     # only recording surfaces allowed
     image = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     with pytest.raises(TypeError):
-        dev.from_recording_surface(image)
+        dev.from_recording_surface(image)  # type: ignore
 
     # No None allowed
     with pytest.raises(TypeError):
-        dev.from_recording_surface(None)
+        dev.from_recording_surface(None)  # type: ignore
 
 
-def test_device_acquire():
+def test_device_acquire() -> None:
     f = io.BytesIO()
     dev = cairo.ScriptDevice(f)
     dev.acquire()
     dev.release()
 
 
-def test_script_device_to_path():
+def test_script_device_to_path() -> None:
     fd, fname = tempfile.mkstemp()
     os.close(fd)
     try:

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -5,7 +5,7 @@ import pytest
 import cairo
 
 
-def test_type():
+def test_type() -> None:
     t = cairo.Antialias
     assert int in t.__mro__
     assert isinstance(t(42), int)
@@ -13,10 +13,10 @@ def test_type():
     assert issubclass(t, int)
 
     with pytest.raises(TypeError):
-        t()
+        t()  # type: ignore
 
     with pytest.raises(TypeError):
-        t(object())
+        t(object())  # type: ignore
 
     with pytest.raises(TypeError):
         type("foo", (t,), {})
@@ -34,24 +34,24 @@ def test_type():
     assert isinstance(cairo.ANTIALIAS_DEFAULT, t)
 
 
-def test_misc():
+def test_misc() -> None:
     cairo.Status.JBIG2_GLOBAL_MISSING
 
 
-def test_format_methods():
+def test_format_methods() -> None:
     assert cairo.Format.RGB24.stride_for_width(8) == 32
     assert cairo.Format.stride_for_width(cairo.Format.RGB24, 8) == 32
 
 
-def test_text_cluster_flags():
+def test_text_cluster_flags() -> None:
     assert cairo.TextClusterFlags.BACKWARD == 1
 
 
-def test_surface_observer_mode():
+def test_surface_observer_mode() -> None:
     assert cairo.SurfaceObserverMode.NORMAL == 0
 
 
-def test_aliases():
+def test_aliases() -> None:
     types_ = [
         cairo.Antialias,
         cairo.Content,
@@ -79,7 +79,7 @@ def test_aliases():
         # cairo 1.18.0+
         types_.append(cairo.Dither)
 
-    def get_prefix(t):
+    def get_prefix(t: type) -> str:
         name = t.__name__
         # special case..
         if name == "PathDataType":
@@ -126,7 +126,7 @@ def test_aliases():
     assert isinstance(cairo.PSLevel.LEVEL_3, cairo.PSLevel)
 
 
-def test_pickle():
+def test_pickle() -> None:
     # These constants used to be plain int. Try to pickle to int so that
     # there is no dependency on pycairo when unpickling.
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -41,7 +41,7 @@ def test_error_check_status():
     str(cairo.Error())
 
 
-def test_error_context():
+def test_error_context() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 100, 100)
     ctx = cairo.Context(surface)
     with pytest.raises(cairo.Error) as excinfo:
@@ -53,7 +53,7 @@ def test_error_context():
     assert str(error)
 
 
-def test_error():
+def test_error() -> None:
     with pytest.raises(cairo.Error) as excinfo:
         raise cairo.Error
     assert excinfo.value.status is None
@@ -73,5 +73,5 @@ def test_error():
     Foo("foo", 42)
 
 
-def test_error_alias():
+def test_error_alias() -> None:
     assert cairo.Error is cairo.CairoError

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -3,27 +3,27 @@ import pytest
 
 
 @pytest.fixture
-def font_options():
-    surface = cairo.ImageSurface(0, 10, 10)
+def font_options() -> cairo.FontOptions:
+    surface = cairo.ImageSurface(cairo.Format(0), 10, 10)
     return surface.get_font_options()
 
 
 @pytest.fixture
-def font_face():
-    surface = cairo.ImageSurface(0, 10, 10)
+def font_face() -> cairo.FontFace:
+    surface = cairo.ImageSurface(cairo.Format(0), 10, 10)
     context = cairo.Context(surface)
     return context.get_font_face()
 
 
 @pytest.fixture
-def scaled_font(font_face, font_options):
+def scaled_font(font_face: cairo.FontFace, font_options: cairo.FontOptions) -> cairo.ScaledFont:
     return cairo.ScaledFont(
         font_face, cairo.Matrix(), cairo.Matrix(), font_options)
 
 
 @pytest.mark.skipif(not hasattr(cairo.FontOptions, "set_custom_palette_color"),
                     reason="too old cairo")
-def test_font_options_custom_palette_color(font_options):
+def test_font_options_custom_palette_color(font_options: cairo.FontOptions) -> None:
     font_options.set_custom_palette_color(42, 0.25, 0.5, 0.75, 1.0)
     with pytest.raises(cairo.Error) as exc_info:
         font_options.get_custom_palette_color(24)
@@ -34,36 +34,36 @@ def test_font_options_custom_palette_color(font_options):
 
 @pytest.mark.skipif(not hasattr(cairo.FontOptions, "set_color_mode"),
                     reason="too old cairo")
-def test_font_options_set_color_mode(font_options):
+def test_font_options_set_color_mode(font_options: cairo.FontOptions) -> None:
     font_options.set_color_mode(cairo.ColorMode.COLOR)
     assert font_options.get_color_mode() == cairo.ColorMode.COLOR
     with pytest.raises(TypeError):
-        font_options.set_color_mode(object())
+        font_options.set_color_mode(object())  # type: ignore
 
 
 @pytest.mark.skipif(not hasattr(cairo.FontOptions, "get_color_mode"),
                     reason="too old cairo")
-def test_font_options_get_color_mode(font_options):
+def test_font_options_get_color_mode(font_options: cairo.FontOptions) -> None:
     assert font_options.get_color_mode() == cairo.ColorMode.DEFAULT
     assert isinstance(font_options.get_color_mode(), cairo.ColorMode)
 
 
 @pytest.mark.skipif(not hasattr(cairo.FontOptions, "set_color_palette"),
                     reason="too old cairo")
-def test_font_options_set_color_palette(font_options):
+def test_font_options_set_color_palette(font_options: cairo.FontOptions) -> None:
     font_options.set_color_palette(42)
     assert font_options.get_color_palette() == 42
 
 
 @pytest.mark.skipif(not hasattr(cairo.FontOptions, "get_color_palette"),
                     reason="too old cairo")
-def test_font_options_get_color_palette(font_options):
+def test_font_options_get_color_palette(font_options: cairo.FontOptions) -> None:
     assert font_options.get_color_palette() == cairo.COLOR_PALETTE_DEFAULT
 
 
 @pytest.mark.skipif(not hasattr(cairo.FontOptions, "get_variations"),
                     reason="too old cairo")
-def test_font_options_variations(font_options):
+def test_font_options_variations(font_options: cairo.FontOptions) -> None:
     assert font_options.get_variations() is None
     font_options.set_variations("foo")
     assert font_options.get_variations() == "foo"
@@ -71,22 +71,22 @@ def test_font_options_variations(font_options):
     assert font_options.get_variations() is None
 
     with pytest.raises(TypeError):
-        font_options.set_variations(1)
+        font_options.set_variations(1)  # type: ignore
 
     with pytest.raises(TypeError):
-        font_options.set_variations("foo", "bar")
+        font_options.set_variations("foo", "bar")  # type: ignore
 
     with pytest.raises(TypeError):
-        font_options.set_variations()
+        font_options.set_variations()  # type: ignore
 
 
-def test_font_options():
+def test_font_options() -> None:
     assert isinstance(cairo.FontOptions(), cairo.FontOptions)
     with pytest.raises(TypeError):
-        cairo.FontOptions(object())
+        cairo.FontOptions(object())  # type: ignore
 
 
-def test_font_options_copy_equal():
+def test_font_options_copy_equal() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_RGB24, 1, 1)
     font_options = surface.get_font_options()
     font_options.set_hint_metrics(cairo.HINT_METRICS_DEFAULT)
@@ -97,17 +97,17 @@ def test_font_options_copy_equal():
     assert not font_options.equal(new)
     assert new.get_hint_metrics() == cairo.HINT_METRICS_DEFAULT
     with pytest.raises(TypeError):
-        font_options.equal(object())
+        font_options.equal(object())  # type: ignore
 
 
-def test_font_options_hash():
+def test_font_options_hash() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_RGB24, 1, 1)
     font_options = surface.get_font_options()
     assert font_options.hash() == font_options.hash()
     assert isinstance(font_options.hash(), int)
 
 
-def test_font_options_merge():
+def test_font_options_merge() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_RGB24, 1, 1)
     font_options = surface.get_font_options()
     font_options.set_hint_metrics(cairo.HINT_METRICS_DEFAULT)
@@ -116,7 +116,7 @@ def test_font_options_merge():
     font_options.merge(new)
     assert font_options.get_hint_metrics() == cairo.HINT_METRICS_ON
     with pytest.raises(TypeError):
-        font_options.merge(object())
+        font_options.merge(object())  # type: ignore
 
 
 def test_font_options_hashable_protocol():
@@ -159,23 +159,23 @@ def test_font_options_set_hint_style(font_options):
         font_options.set_hint_style(object())
 
 
-def test_font_options_set_subpixel_order(font_options):
+def test_font_options_set_subpixel_order(font_options: cairo.FontOptions) -> None:
     font_options.set_subpixel_order(cairo.SubpixelOrder.VRGB)
     assert font_options.get_subpixel_order() == cairo.SubpixelOrder.VRGB
     with pytest.raises(TypeError):
-        font_options.set_subpixel_order(object())
+        font_options.set_subpixel_order(object())  # type: ignore
 
 
-def test_font_face(font_face):
+def test_font_face(font_face: cairo.FontFace) -> None:
     with pytest.raises(TypeError):
-        cairo.FontFace()
+        cairo.FontFace()  # type: ignore
 
     assert font_face == font_face
     assert font_face != object()
 
 
-def test_font_face_cmp_hash():
-    surface = cairo.ImageSurface(0, 10, 10)
+def test_font_face_cmp_hash() -> None:
+    surface = cairo.ImageSurface(cairo.Format(0), 10, 10)
     context = cairo.Context(surface)
     ff = context.get_font_face()
     other = context.get_font_face()
@@ -184,58 +184,58 @@ def test_font_face_cmp_hash():
     assert hash(ff) == hash(other)
 
     sf = context.get_scaled_font()
-    other = context.get_scaled_font()
-    assert sf == other
-    assert not sf != other
-    assert hash(sf) == hash(other)
+    other_sf = context.get_scaled_font()
+    assert sf == other_sf
+    assert not sf != other_sf
+    assert hash(sf) == hash(other_sf)
 
     fo = context.get_font_options()
     # FontOptions compare by their content and they are mutable, so not
     # hashable.
     with pytest.raises(TypeError):
-        hash(fo)
+        hash(fo)  # type: ignore
 
 
-def test_scaled_font(scaled_font):
+def test_scaled_font(scaled_font: cairo.ScaledFont) -> None:
     with pytest.raises(TypeError):
-        cairo.ScaledFont()
+        cairo.ScaledFont()  # type: ignore
 
     assert scaled_font == scaled_font
     assert scaled_font != object()
 
 
-def test_scaled_font_extents(scaled_font):
+def test_scaled_font_extents(scaled_font: cairo.ScaledFont) -> None:
     assert isinstance(scaled_font.extents(), tuple)
 
 
-def test_scaled_font_get_font_face(scaled_font):
+def test_scaled_font_get_font_face(scaled_font: cairo.ScaledFont) -> None:
     assert isinstance(scaled_font.get_font_face(), cairo.FontFace)
 
 
-def test_scaled_font_get_scale_matrix(scaled_font):
+def test_scaled_font_get_scale_matrix(scaled_font: cairo.ScaledFont) -> None:
     assert isinstance(scaled_font.get_scale_matrix(), cairo.Matrix)
 
 
-def test_scaled_font_text_extents(scaled_font):
+def test_scaled_font_text_extents(scaled_font: cairo.ScaledFont) -> None:
     with pytest.raises(TypeError):
-        scaled_font.text_extents(object())
+        scaled_font.text_extents(object())  # type: ignore
 
 
-def test_scaled_font_glyph_extents(scaled_font):
+def test_scaled_font_glyph_extents(scaled_font: cairo.ScaledFont) -> None:
     with pytest.raises(TypeError):
-        scaled_font.glyph_extents(object())
+        scaled_font.glyph_extents(object())  # type: ignore
     with pytest.raises(TypeError):
-        scaled_font.glyph_extents([object()])
+        scaled_font.glyph_extents([object()])  # type: ignore
     with pytest.raises(TypeError):
-        scaled_font.glyph_extents()
+        scaled_font.glyph_extents()  # type: ignore
 
 
-def test_toy_font_face():
+def test_toy_font_face() -> None:
     with pytest.raises(TypeError):
-        cairo.ToyFontFace(object())
+        cairo.ToyFontFace(object())  # type: ignore
 
 
-def test_toy_font_get_family():
+def test_toy_font_get_family() -> None:
     font_face = cairo.ToyFontFace("")
     assert isinstance(font_face.get_family(), str)
     font_face = cairo.ToyFontFace("serif")
@@ -244,64 +244,64 @@ def test_toy_font_get_family():
     assert isinstance(font_face.get_family(), str)
 
 
-def test_toy_font_get_slant():
+def test_toy_font_get_slant() -> None:
     font_face = cairo.ToyFontFace("")
     assert font_face.get_slant() == cairo.FontSlant.NORMAL
     assert isinstance(font_face.get_slant(), cairo.FontSlant)
 
 
-def test_toy_font_get_weight():
+def test_toy_font_get_weight() -> None:
     font_face = cairo.ToyFontFace("")
     assert font_face.get_weight() == cairo.FontWeight.NORMAL
     assert isinstance(font_face.get_weight(), cairo.FontWeight)
 
 
-def test_font_options_get_antialias(font_options):
+def test_font_options_get_antialias(font_options: cairo.FontOptions) -> None:
     assert font_options.get_antialias() == cairo.Antialias.DEFAULT
     assert isinstance(font_options.get_antialias(), cairo.Antialias)
 
 
-def test_font_options_get_hint_metrics(font_options):
+def test_font_options_get_hint_metrics(font_options: cairo.FontOptions) -> None:
     assert font_options.get_hint_metrics() == cairo.HintMetrics.ON
     assert isinstance(font_options.get_hint_metrics(), cairo.HintMetrics)
 
 
-def test_font_options_get_hint_style(font_options):
+def test_font_options_get_hint_style(font_options: cairo.FontOptions) -> None:
     assert font_options.get_hint_style() == cairo.HintStyle.DEFAULT
     assert isinstance(font_options.get_hint_style(), cairo.HintStyle)
 
 
-def test_font_options_get_subpixel_order(font_options):
+def test_font_options_get_subpixel_order(font_options: cairo.FontOptions) -> None:
     assert font_options.get_subpixel_order() == cairo.SubpixelOrder.DEFAULT
     assert isinstance(font_options.get_subpixel_order(), cairo.SubpixelOrder)
 
 
-def test_scaled_font_get_ctm():
-    surface = cairo.ImageSurface(0, 10, 10)
+def test_scaled_font_get_ctm() -> None:
+    surface = cairo.ImageSurface(cairo.Format(0), 10, 10)
     ctx = cairo.Context(surface)
     sf = ctx.get_scaled_font()
     matrix = sf.get_ctm()
     assert isinstance(matrix, cairo.Matrix)
 
 
-def test_scaled_font_get_font_matrix():
-    surface = cairo.ImageSurface(0, 10, 10)
+def test_scaled_font_get_font_matrix() -> None:
+    surface = cairo.ImageSurface(cairo.Format(0), 10, 10)
     ctx = cairo.Context(surface)
     sf = ctx.get_scaled_font()
     matrix = sf.get_font_matrix()
     assert isinstance(matrix, cairo.Matrix)
 
 
-def test_scaled_font_get_font_options():
-    surface = cairo.ImageSurface(0, 10, 10)
+def test_scaled_font_get_font_options() -> None:
+    surface = cairo.ImageSurface(cairo.Format(0), 10, 10)
     ctx = cairo.Context(surface)
     sf = ctx.get_scaled_font()
     font_options = sf.get_font_options()
     assert isinstance(font_options, cairo.FontOptions)
 
 
-def test_scaled_font_text_to_glyphs():
-    surface = cairo.ImageSurface(0, 10, 10)
+def test_scaled_font_text_to_glyphs() -> None:
+    surface = cairo.ImageSurface(cairo.Format(0), 10, 10)
     ctx = cairo.Context(surface)
     sf = ctx.get_scaled_font()
     assert sf.text_to_glyphs(0, 0, "") == ([], [], 0)
@@ -319,4 +319,4 @@ def test_scaled_font_text_to_glyphs():
     assert len(clusters) == 3
 
     with pytest.raises(TypeError):
-        sf.text_to_glyphs(object())
+        sf.text_to_glyphs(object())  # type: ignore

--- a/tests/test_fspaths.py
+++ b/tests/test_fspaths.py
@@ -26,7 +26,7 @@ class _PathLike:
         return self._value
 
 
-def test_fspaths(tempdir_path):
+def test_fspaths(tempdir_path) -> None:
     def write(path):
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
         surface.write_to_png(path)

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -5,12 +5,12 @@ import cairo
 import pytest
 
 
-def test_type():
-    assert cairo.Glyph
+def test_type() -> None:
+    assert hasattr(cairo, "Glyph")
     assert issubclass(cairo.Glyph, tuple)
 
     with pytest.raises(TypeError):
-        cairo.Glyph()
+        cairo.Glyph()  # type: ignore
 
     g = cairo.Glyph(0, 0.5, 0.25)
     assert hash(g) == hash(cairo.Glyph(0, 0.5, 0.25))
@@ -23,7 +23,7 @@ def test_type():
     assert g.y == 0.25
 
     with pytest.raises(AttributeError):
-        assert g.z
+        assert g.z  # type: ignore
 
     assert repr(cairo.Glyph(0, 0, 0)) == \
         "cairo.Glyph(index=0, x=0.0, y=0.0)"
@@ -52,7 +52,7 @@ def test_context():
         context.glyph_path([object()])
 
 
-def test_glyph_limits():
+def test_glyph_limits() -> None:
     max_ulong = 2 ** (ctypes.sizeof(ctypes.c_ulong()) * 8) - 1
 
     g = cairo.Glyph(max_ulong, sys.float_info.max, -sys.float_info.max)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -2,20 +2,20 @@ import cairo
 import pytest
 
 
-def test_matrix():
+def test_matrix() -> None:
     m = cairo.Matrix()
     m.rotate(10)
     m.scale(1.5, 2.5)
     m.translate(10, 20)
 
     with pytest.raises(TypeError):
-        m * 42
+        m * 42  # type: ignore
 
     with pytest.raises(TypeError):
-        m + 42
+        m + 42  # type: ignore
 
     with pytest.raises(TypeError):
-        cairo.Matrix(object())
+        cairo.Matrix(object())  # type: ignore
 
     assert m != 42
     assert m == m
@@ -24,21 +24,21 @@ def test_matrix():
     assert repr(cairo.Matrix()) == "cairo.Matrix(1, 0, 0, 1, 0, 0)"
 
 
-def test_init_rotate():
+def test_init_rotate() -> None:
     r = cairo.Matrix.init_rotate(0)
     assert cairo.Matrix() == r
 
     with pytest.raises(TypeError):
-        cairo.Matrix.init_rotate(object())
+        cairo.Matrix.init_rotate(object())  # type: ignore
 
 
-def test_invert():
+def test_invert() -> None:
     m = cairo.Matrix(1, 1)
     m.invert()
     assert m == cairo.Matrix(1, -1, -0, 1, 0, 0)
 
 
-def test_matrix_properties():
+def test_matrix_properties() -> None:
     m = cairo.Matrix(*range(6))
     assert [m.xx, m.yx, m.xy, m.yy, m.x0, m.y0] == list(range(6))
     m.xx = 42
@@ -66,39 +66,39 @@ def test_multiply():
     assert m * m == m.multiply(m)
 
 
-def test_translate():
+def test_translate() -> None:
     m = cairo.Matrix()
     m.translate(1, 1)
     assert m == cairo.Matrix(1, 0, 0, 1, 1, 1)
     with pytest.raises(TypeError):
-        m.translate(1, object())
+        m.translate(1, object())  # type: ignore
 
 
-def test_rotate():
+def test_rotate() -> None:
     m = cairo.Matrix()
     with pytest.raises(TypeError):
-        m.rotate(object())
+        m.rotate(object())  # type: ignore
 
 
-def test_scale():
+def test_scale() -> None:
     m = cairo.Matrix()
     with pytest.raises(TypeError):
-        m.scale(object())
+        m.scale(object())  # type: ignore
     m.scale(2, 2)
     assert m != cairo.Matrix()
     m.scale(0.5, 0.5)
     assert m == cairo.Matrix()
 
 
-def test_transform_distance():
+def test_transform_distance() -> None:
     m = cairo.Matrix()
     assert m.transform_distance(1, 1) == (1, 1)
     with pytest.raises(TypeError):
-        m.transform_distance(1, object())
+        m.transform_distance(1, object())  # type: ignore
 
 
-def test_transform_point():
+def test_transform_point() -> None:
     m = cairo.Matrix()
     assert m.transform_point(1, 1) == (1, 1)
     with pytest.raises(TypeError):
-        m.transform_point(1, object())
+        m.transform_point(1, object())  # type: ignore

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -3,19 +3,19 @@ import pytest
 
 
 @pytest.fixture
-def context():
+def context() -> cairo.Context:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 42, 42)
     return cairo.Context(surface)
 
 
-def test_path():
-    assert cairo.Path
+def test_path() -> None:
+    assert hasattr(cairo, "Path")
 
     with pytest.raises(TypeError):
         cairo.Path()
 
 
-def test_path_str(context):
+def test_path_str(context: cairo.Context) -> None:
     p = context.copy_path()
     assert isinstance(p, cairo.Path)
     assert str(p) == ""

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -2,13 +2,13 @@ import cairo
 import pytest
 
 
-def test_raster_source():
+def test_raster_source() -> None:
     pattern = cairo.RasterSourcePattern(cairo.Content.COLOR, 2, 2)
     assert isinstance(pattern, cairo.RasterSourcePattern)
     assert issubclass(cairo.RasterSourcePattern, cairo.Pattern)
 
     with pytest.raises(TypeError):
-        cairo.RasterSourcePattern(object())
+        cairo.RasterSourcePattern(object())  # type: ignore
 
     was_called = []
 
@@ -27,7 +27,7 @@ def test_raster_source():
         return None
 
     with pytest.raises(TypeError):
-        pattern.set_acquire()
+        pattern.set_acquire()  # type: ignore
 
     pattern.set_acquire(None, release_callback)
     assert pattern.get_acquire() == (None, release_callback)
@@ -48,13 +48,13 @@ def test_raster_source():
     assert was_called == ["acquire", "release"]
 
     with pytest.raises(TypeError):
-        pattern.set_acquire(None, object())
+        pattern.set_acquire(None, object())  # type: ignore
 
     with pytest.raises(TypeError):
-        pattern.set_acquire(object(), None)
+        pattern.set_acquire(object(), None)  # type: ignore
 
 
-def test_cmp_hash():
+def test_cmp_hash() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     context = cairo.Context(surface)
     pattern = context.get_source()
@@ -63,28 +63,28 @@ def test_cmp_hash():
     assert not pattern != other
 
 
-def test_get_extend():
+def test_get_extend() -> None:
     pattern = cairo.SolidPattern(1, 2, 4)
     assert pattern.get_extend() == cairo.Extend.PAD
     assert isinstance(pattern.get_extend(), cairo.Extend)
 
 
-def test_get_filter():
+def test_get_filter() -> None:
     pattern = cairo.SolidPattern(1, 2, 4)
     assert pattern.get_filter() == cairo.Filter.GOOD
 
 
-def test_linear_gradient():
+def test_linear_gradient() -> None:
     with pytest.raises(TypeError):
-        cairo.LinearGradient()
+        cairo.LinearGradient()  # type: ignore
 
 
-def test_radial_gradient():
+def test_radial_gradient() -> None:
     with pytest.raises(TypeError):
-        cairo.RadialGradient()
+        cairo.RadialGradient()  # type: ignore
 
 
-def test_gradient_get_color_stops():
+def test_gradient_get_color_stops() -> None:
     pattern = cairo.LinearGradient(1, 2, 4, 5)
     assert pattern.get_color_stops_rgba() == []
     pattern.add_color_stop_rgb(0.125, 0.25, 0.5, 0.75)
@@ -94,32 +94,32 @@ def test_gradient_get_color_stops():
         [(0.125, 0.25, 0.5, 0.75, 1.0), (1.0, 0.75, 0.5, 0.25, 0.125)]
 
 
-def test_gradient_add_color_stop_rgb():
+def test_gradient_add_color_stop_rgb() -> None:
     pattern = cairo.LinearGradient(1, 2, 4, 5)
     with pytest.raises(TypeError):
-        pattern.add_color_stop_rgb()
+        pattern.add_color_stop_rgb()  # type: ignore
 
 
-def test_gradient_add_color_stop_rgba():
+def test_gradient_add_color_stop_rgba() -> None:
     pattern = cairo.LinearGradient(1, 2, 4, 5)
     with pytest.raises(TypeError):
-        pattern.add_color_stop_rgba()
+        pattern.add_color_stop_rgba()  # type: ignore
 
 
-def test_solid_pattern():
+def test_solid_pattern() -> None:
     with pytest.raises(TypeError):
-        cairo.SolidPattern()
+        cairo.SolidPattern()  # type: ignore
 
 
-def test_mesh_pattern():
+def test_mesh_pattern() -> None:
     mesh = cairo.MeshPattern()
     assert isinstance(mesh, cairo.MeshPattern)
     assert issubclass(cairo.MeshPattern, cairo.Pattern)
     with pytest.raises(TypeError):
-        cairo.MeshPattern(object())
+        cairo.MeshPattern(object())  # type: ignore
 
 
-def test_mesh_pattern_example1():
+def test_mesh_pattern_example1() -> None:
     pattern = cairo.MeshPattern()
     assert pattern.get_patch_count() == 0
 
@@ -149,61 +149,61 @@ def test_mesh_pattern_example1():
         pattern.get_path(9)
 
 
-def test_mesh_pattern_curve_to():
+def test_mesh_pattern_curve_to() -> None:
     pattern = cairo.MeshPattern()
     with pytest.raises(TypeError):
-        pattern.curve_to(object())
+        pattern.curve_to(object())  # type: ignore
 
 
-def test_mesh_pattern_get_control_point():
+def test_mesh_pattern_get_control_point() -> None:
     pattern = cairo.MeshPattern()
     with pytest.raises(TypeError):
-        pattern.get_control_point(object())
+        pattern.get_control_point(object())  # type: ignore
 
 
-def test_mesh_pattern_get_corner_color_rgba():
+def test_mesh_pattern_get_corner_color_rgba() -> None:
     pattern = cairo.MeshPattern()
     with pytest.raises(TypeError):
-        pattern.get_corner_color_rgba(object())
+        pattern.get_corner_color_rgba(object())  # type: ignore
 
 
-def test_mesh_pattern_get_path():
+def test_mesh_pattern_get_path() -> None:
     pattern = cairo.MeshPattern()
     with pytest.raises(TypeError):
-        pattern.get_path(object())
+        pattern.get_path(object())  # type: ignore
 
 
-def test_mesh_pattern_line_to():
+def test_mesh_pattern_line_to() -> None:
     pattern = cairo.MeshPattern()
     with pytest.raises(TypeError):
-        pattern.line_to(object())
+        pattern.line_to(object())  # type: ignore
 
 
-def test_mesh_pattern_move_to():
+def test_mesh_pattern_move_to() -> None:
     pattern = cairo.MeshPattern()
     with pytest.raises(TypeError):
-        pattern.move_to(object())
+        pattern.move_to(object())  # type: ignore
 
 
-def test_mesh_pattern_set_control_point():
+def test_mesh_pattern_set_control_point() -> None:
     pattern = cairo.MeshPattern()
     with pytest.raises(TypeError):
-        pattern.set_control_point(object())
+        pattern.set_control_point(object())  # type: ignore
 
 
-def test_mesh_pattern_set_corner_color_rgb():
+def test_mesh_pattern_set_corner_color_rgb() -> None:
     pattern = cairo.MeshPattern()
     with pytest.raises(TypeError):
-        pattern.set_corner_color_rgb(object())
+        pattern.set_corner_color_rgb(object())  # type: ignore
 
 
-def test_mesh_pattern_set_corner_color_rgba():
+def test_mesh_pattern_set_corner_color_rgba() -> None:
     pattern = cairo.MeshPattern()
     with pytest.raises(TypeError):
-        pattern.set_corner_color_rgba(object())
+        pattern.set_corner_color_rgba(object())  # type: ignore
 
 
-def test_mesh_pattern_example2():
+def test_mesh_pattern_example2() -> None:
     pattern = cairo.MeshPattern()
     pattern.begin_patch()
     pattern.move_to(100, 100)
@@ -215,7 +215,7 @@ def test_mesh_pattern_example2():
     pattern.end_patch()
 
 
-def test_mesh_pattern_rest():
+def test_mesh_pattern_rest() -> None:
     pattern = cairo.MeshPattern()
     pattern.begin_patch()
     pattern.curve_to(0, 1, 2, 3, 4, 5)
@@ -235,7 +235,7 @@ def test_mesh_pattern_rest():
         pattern.get_control_point(0, 9)
 
 
-def test_mesh_pattern_error_states():
+def test_mesh_pattern_error_states() -> None:
     pattern = cairo.MeshPattern()
     pattern.begin_patch()
     with pytest.raises(cairo.Error):
@@ -260,70 +260,70 @@ def test_mesh_pattern_error_states():
         cairo.MeshPattern().set_corner_color_rgb(0, 0.125, 0.25, 0.5)
 
 
-def test_get_matrix():
+def test_get_matrix() -> None:
     pattern = cairo.SolidPattern(1, 2, 4)
     assert isinstance(pattern.get_matrix(), cairo.Matrix)
     pattern.set_matrix(cairo.Matrix())
     with pytest.raises(TypeError):
-        pattern.set_matrix(object())
+        pattern.set_matrix(object())  # type: ignore
 
 
-def test_set_extend():
+def test_set_extend() -> None:
     pattern = cairo.SolidPattern(1, 2, 4)
-    pattern.set_extend(42)
+    pattern.set_extend(42)  # type: ignore
     assert pattern.get_extend() == 42
     with pytest.raises(TypeError):
-        pattern.set_extend(object())
+        pattern.set_extend(object())  # type: ignore
 
 
-def test_set_filter():
+def test_set_filter() -> None:
     pattern = cairo.SolidPattern(1, 2, 4)
     with pytest.raises(TypeError):
-        pattern.set_filter(object())
+        pattern.set_filter(object())  # type: ignore
 
 
-def test_pattern():
+def test_pattern() -> None:
     with pytest.raises(TypeError):
-        cairo.Pattern()
+        cairo.Pattern()  # type: ignore
 
     r, g, b, a = 0.1, 0.2, 0.3, 0.4
-    p = cairo.SolidPattern(r, g, b, a)
-    assert p.get_rgba() == (r, g, b, a)
+    solid = cairo.SolidPattern(r, g, b, a)
+    assert solid.get_rgba() == (r, g, b, a)
 
-    assert not p == object()
-    hash(p)
+    assert not solid == object()
+    hash(solid)
 
     with pytest.raises(TypeError):
-        cairo.Gradient()
+        cairo.Gradient()  # type: ignore
 
     x0, y0, x1, y1 = 0.0, 0.0, 0.0, 1.0
-    p = cairo.LinearGradient(x0, y0, x1, y1)
-    assert p.get_linear_points() == (x0, y0, x1, y1)
-    p.add_color_stop_rgba(1, 0, 0, 0, 1)
-    p.add_color_stop_rgba(0, 1, 1, 1, 1)
+    linear = cairo.LinearGradient(x0, y0, x1, y1)
+    assert linear.get_linear_points() == (x0, y0, x1, y1)
+    linear.add_color_stop_rgba(1, 0, 0, 0, 1)
+    linear.add_color_stop_rgba(0, 1, 1, 1, 1)
 
     cx0, cy0, radius0, cx1, cy1, radius1 = 1.0, 1.0, 1.0, 2.0, 2.0, 1.0
-    p = cairo.RadialGradient(cx0, cy0, radius0, cx1, cy1, radius1)
-    assert p.get_radial_circles() == (cx0, cy0, radius0, cx1, cy1, radius1)
-    p.add_color_stop_rgba(0, 1, 1, 1, 1)
-    p.add_color_stop_rgba(1, 0, 0, 0, 1)
+    radial = cairo.RadialGradient(cx0, cy0, radius0, cx1, cy1, radius1)
+    assert radial.get_radial_circles() == (cx0, cy0, radius0, cx1, cy1, radius1)
+    radial.add_color_stop_rgba(0, 1, 1, 1, 1)
+    radial.add_color_stop_rgba(1, 0, 0, 0, 1)
 
 
-def test_pattern_filter():
+def test_pattern_filter() -> None:
     pattern = cairo.SolidPattern(1, 2, 3)
     assert pattern.get_filter() == cairo.FILTER_GOOD
     pattern.set_filter(cairo.FILTER_NEAREST)
     assert pattern.get_filter() == cairo.FILTER_NEAREST
 
 
-def test_surface_pattern():
+def test_surface_pattern() -> None:
     with pytest.raises(TypeError):
-        cairo.SurfacePattern(object())
+        cairo.SurfacePattern(object())  # type: ignore
 
 
 @pytest.mark.skipif(not hasattr(cairo.Pattern, "set_dither"),
                     reason="too old cairo")
-def test_pattern_dither():
+def test_pattern_dither() -> None:
     pattern = cairo.SolidPattern(1, 2, 3)
     pattern.get_dither() == cairo.Dither.DEFAULT
     pattern.set_dither(cairo.Dither.BEST)

--- a/tests/test_rectangle.py
+++ b/tests/test_rectangle.py
@@ -4,12 +4,12 @@ import cairo
 import pytest
 
 
-def test_type():
-    assert cairo.Rectangle
+def test_type() -> None:
+    assert hasattr(cairo, "Rectangle")
     assert issubclass(cairo.Rectangle, tuple)
 
     with pytest.raises(TypeError):
-        cairo.Rectangle()
+        cairo.Rectangle()  # type: ignore
 
     r = cairo.Rectangle(0.0, 0.5, 0.25, 0.75)
     assert hash(r) == hash(cairo.Rectangle(0.0, 0.5, 0.25, 0.75))
@@ -23,7 +23,7 @@ def test_type():
     assert r.y == 0.5
 
     with pytest.raises(AttributeError):
-        assert r.z
+        assert r.z  # type: ignore
 
     assert repr(r) == "cairo.Rectangle(x=0.0, y=0.5, width=0.25, height=0.75)"
     assert str(r) == repr(r)
@@ -35,7 +35,7 @@ def test_type():
     assert cairo.Rectangle.height
 
 
-def test_context():
+def test_context() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     context = cairo.Context(surface)
     context.line_to(0, 5)
@@ -50,14 +50,14 @@ def test_context():
     assert isinstance(rects[0], cairo.Rectangle)
 
 
-def test_recording_surface():
+def test_recording_surface() -> None:
     surface = cairo.RecordingSurface(
         cairo.CONTENT_COLOR, cairo.Rectangle(1, 1, 10, 10))
 
     assert isinstance(surface.get_extents(), cairo.Rectangle)
 
 
-def test_rectangle_limits():
+def test_rectangle_limits() -> None:
     max_val = sys.float_info.max
     min_val = -sys.float_info.max
 

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -4,18 +4,18 @@ import cairo
 import pytest
 
 
-def test_region():
+def test_region() -> None:
     with pytest.raises(TypeError):
-        cairo.Region(object())
-
-    with pytest.raises(TypeError):
-        cairo.Region(object(), object())
+        cairo.Region(object())  # type: ignore
 
     with pytest.raises(TypeError):
-        cairo.Region([object()])
+        cairo.Region(object(), object())  # type: ignore
+
+    with pytest.raises(TypeError):
+        cairo.Region([object()])  # type: ignore
 
 
-def test_get_rectangle():
+def test_get_rectangle() -> None:
     rect = cairo.RectangleInt(0, 0, 10, 10)
     r = cairo.Region(rect)
     with pytest.raises(ValueError):
@@ -24,10 +24,10 @@ def test_get_rectangle():
         r.get_rectangle(1)
     assert r.get_rectangle(0) == rect
     with pytest.raises(TypeError):
-        r.get_rectangle(object())
+        r.get_rectangle(object())  # type: ignore
 
 
-def test_rectangles_limits():
+def test_rectangles_limits() -> None:
     max_int = 2 ** (ctypes.sizeof(ctypes.c_int()) * 8 - 1) - 1
     min_int = -max_int - 1
 
@@ -43,115 +43,115 @@ def test_rectangles_limits():
         cairo.RectangleInt(min_int, min_int, max_int, min_int - 1)
 
 
-def test_contains_point():
+def test_contains_point() -> None:
     rect = cairo.RectangleInt(0, 0, 10, 10)
     r = cairo.Region(rect)
     assert r.contains_point(0, 0)
     assert not r.contains_point(0, 20)
     with pytest.raises(TypeError):
-        r.contains_point(0, object())
+        r.contains_point(0, object())  # type: ignore
 
 
-def test_intersect():
+def test_intersect() -> None:
     rect = cairo.RectangleInt(0, 0, 10, 10)
     r = cairo.Region(rect)
     r.intersect(r)
     r.intersect(rect)
     with pytest.raises(TypeError):
-        r.intersect(object())
+        r.intersect(object())  # type: ignore
     with pytest.raises(TypeError):
-        r.intersect()
+        r.intersect()  # type: ignore
 
     assert r.__eq__(object()) == NotImplemented
     assert rect.__eq__(object()) == NotImplemented
 
 
-def test_equal():
+def test_equal() -> None:
     rect = cairo.RectangleInt(0, 0, 10, 10)
     r = cairo.Region(rect)
     assert r.equal(r)
     with pytest.raises(TypeError):
-        r.equal(object())
+        r.equal(object())  # type: ignore
     with pytest.raises(TypeError):
-        r.equal()
+        r.equal()  # type: ignore
 
 
-def test_subtract():
+def test_subtract() -> None:
     rect = cairo.RectangleInt(0, 0, 10, 10)
     r = cairo.Region(rect)
     r.subtract(r)
     with pytest.raises(TypeError):
-        r.subtract(object())
+        r.subtract(object())  # type: ignore
     with pytest.raises(TypeError):
-        r.subtract()
+        r.subtract()  # type: ignore
 
 
-def test_union():
+def test_union() -> None:
     rect = cairo.RectangleInt(0, 0, 10, 10)
     r = cairo.Region(rect)
     r.union(r)
     r.union(rect)
     with pytest.raises(TypeError):
-        r.union(object())
+        r.union(object())  # type: ignore
     with pytest.raises(TypeError):
-        r.union()
+        r.union()  # type: ignore
 
 
-def test_xor():
+def test_xor() -> None:
     rect = cairo.RectangleInt(0, 0, 10, 10)
     r = cairo.Region(rect)
     r.xor(r)
     r.xor(rect)
     with pytest.raises(TypeError):
-        r.xor(object())
+        r.xor(object())  # type: ignore
     with pytest.raises(TypeError):
-        r.xor()
+        r.xor()  # type: ignore
 
 
-def test_translate():
+def test_translate() -> None:
     r = cairo.Region()
     r.translate(1, 1)
     with pytest.raises(TypeError):
-        r.translate(1, object())
+        r.translate(1, object())  # type: ignore
 
 
-def test_region_contains_rectangle():
+def test_region_contains_rectangle() -> None:
     rect = cairo.RectangleInt(1, 2, 10, 13)
     region = cairo.Region()
     assert region.contains_rectangle(rect) == cairo.RegionOverlap.OUT
     assert isinstance(region.contains_rectangle(rect), cairo.RegionOverlap)
     with pytest.raises(TypeError):
-        region.contains_rectangle(object())
+        region.contains_rectangle(object())  # type: ignore
 
 
-def test_region_cmp_hash():
+def test_region_cmp_hash() -> None:
     region = cairo.Region()
-    other = cairo.Region()
+    other_region = cairo.Region()
     differ = cairo.Region(cairo.RectangleInt(0, 0, 10, 10))
     with pytest.raises(TypeError):
         hash(region)
     assert region == region
-    assert region == other
-    assert not region != other
+    assert region == other_region
+    assert not region != other_region
     assert region != differ
 
     with pytest.raises(TypeError):
-        region < region
+        region < region  # type: ignore
 
     with pytest.raises(TypeError):
-        region > region
+        region > region  # type: ignore
 
     rect = cairo.RectangleInt(1, 2, 10, 13)
     same = cairo.RectangleInt(1, 2, 10, 13)
-    other = cairo.RectangleInt(2, 2, 10, 13)
+    other_rect = cairo.RectangleInt(2, 2, 10, 13)
     with pytest.raises(TypeError):
         hash(rect)
 
     assert rect == same
-    assert rect != other
+    assert rect != other_rect
 
     with pytest.raises(TypeError):
-        rect < same
+        rect < same  # type: ignore
 
     with pytest.raises(TypeError):
-        rect > same
+        rect > same  # type: ignore

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -1,8 +1,0 @@
-import typing
-import cairo
-import pathlib
-
-if typing.TYPE_CHECKING:
-    cairo.PSSurface(b"", 0, 0)
-    cairo.PSSurface("", 0, 0)
-    cairo.PSSurface(pathlib.Path(""), 0, 0)

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -10,7 +10,7 @@ import cairo
 import pytest
 
 
-def test_context_manager():
+def test_context_manager() -> None:
     with cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10) as surface:
         surface.show_page()
     with pytest.raises(cairo.Error) as excinfo:
@@ -18,7 +18,7 @@ def test_context_manager():
     assert excinfo.value.status == cairo.Status.SURFACE_FINISHED
 
 
-def test_surface_cmp_hash():
+def test_surface_cmp_hash() -> None:
     main = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     ctx = cairo.Context(main)
     assert ctx.get_target() == main
@@ -35,12 +35,12 @@ def test_surface_cmp_hash():
     main.unmap_image(mapped)
 
 
-def test_surface_map_to_image():
+def test_surface_map_to_image() -> None:
     main = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     image = main.map_to_image(None)
 
     with pytest.raises(TypeError):
-        type(image)()
+        type(image)()  # type: ignore
 
     other = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     with pytest.raises(ValueError):
@@ -62,16 +62,16 @@ def test_surface_map_to_image():
         cairo.Context(image)
 
     with pytest.raises(TypeError):
-        main.map_to_image(object())
+        main.map_to_image(object())  # type: ignore
 
     with pytest.raises(TypeError):
-        main.map_to_image()
+        main.map_to_image()  # type: ignore
 
     gced = main.map_to_image(None)
     del gced
 
 
-def test_surface_map_to_image_context_manager():
+def test_surface_map_to_image_context_manager() -> None:
     main = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     with main.map_to_image(None) as image:
         pass
@@ -88,7 +88,7 @@ def test_surface_map_to_image_context_manager():
             pass
 
 
-def test_surface_map_to_image_data():
+def test_surface_map_to_image_data() -> None:
     main = cairo.ImageSurface(cairo.Format.RGB24, 2, 1)
 
     main.flush()
@@ -112,18 +112,18 @@ def test_surface_map_to_image_data():
 
 
 @pytest.mark.skipif(not cairo.HAS_TEE_SURFACE, reason="no tee surface")
-def test_tee_surface():
+def test_tee_surface() -> None:
     main = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     tee = cairo.TeeSurface(main)
     assert isinstance(tee, cairo.TeeSurface)
     with pytest.raises(TypeError):
-        cairo.TeeSurface(object())
+        cairo.TeeSurface(object())  # type: ignore
     with pytest.raises(TypeError):
-        tee.add(object())
+        tee.add(object())  # type: ignore
     with pytest.raises(TypeError):
-        tee.remove(object())
+        tee.remove(object())  # type: ignore
     with pytest.raises(TypeError):
-        tee.index(object())
+        tee.index(object())  # type: ignore
     # the API is horrible, passing a wrong arg sets the surface to an error
     # state instead of returning the status.
     s1 = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
@@ -134,7 +134,7 @@ def test_tee_surface():
 
 
 @pytest.mark.skipif(not hasattr(sys, "getrefcount"), reason="PyPy")
-def test_image_surface_get_data_refcount():
+def test_image_surface_get_data_refcount() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     refcount = sys.getrefcount(surface)
     d = surface.get_data()
@@ -143,7 +143,7 @@ def test_image_surface_get_data_refcount():
     assert sys.getrefcount(surface) == refcount
 
 
-def test_image_surface_get_data_crasher():
+def test_image_surface_get_data_crasher() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     try:
         assert 0, surface.get_data()
@@ -151,43 +151,43 @@ def test_image_surface_get_data_crasher():
         pass
 
 
-def test_surface_get_content():
+def test_surface_get_content() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     assert surface.get_content() == cairo.Content.COLOR_ALPHA
     assert isinstance(surface.get_content(), cairo.Content)
 
 
-def test_surface_get_format():
+def test_surface_get_format() -> None:
     surface = cairo.ImageSurface(cairo.Format.ARGB32, 10, 10)
     assert surface.get_format() == cairo.Format.ARGB32
     assert isinstance(surface.get_format(), cairo.Format)
 
 
-def test_pdf_get_error():
+def test_pdf_get_error() -> None:
     cairo.PDFSurface(io.BytesIO(), 10, 10)
     with pytest.raises(TypeError):
-        cairo.PDFSurface(object(), 10, 10)
+        cairo.PDFSurface(object(), 10, 10)  # type: ignore
     with pytest.raises(TypeError):
-        cairo.PDFSurface(io.StringIO(), 10, 10)
+        cairo.PDFSurface(io.StringIO(), 10, 10)  # type: ignore
 
 
-def test_pdf_get_versions():
+def test_pdf_get_versions() -> None:
     versions = cairo.PDFSurface.get_versions()
     assert isinstance(versions, list)
     assert all(isinstance(v, cairo.PDFVersion) for v in versions)
 
 
-def test_pdf_set_size():
+def test_pdf_set_size() -> None:
     fileobj = io.BytesIO()
     surface = cairo.PDFSurface(fileobj, 128, 128)
     surface.set_size(10, 10)
     with pytest.raises(TypeError):
-        surface.set_size(10, object())
+        surface.set_size(10, object())  # type: ignore
 
 
 @pytest.mark.skipif(not hasattr(cairo.PDFSurface, "set_page_label"),
                     reason="too old cairo")
-def test_pdf_set_page_label():
+def test_pdf_set_page_label() -> None:
     fileobj = io.BytesIO()
     with cairo.PDFSurface(fileobj, 128, 128) as surface:
         surface.set_page_label("foo")
@@ -198,7 +198,7 @@ def test_pdf_set_page_label():
 
 @pytest.mark.skipif(not hasattr(cairo.PDFSurface, "set_metadata"),
                     reason="too old cairo")
-def test_pdf_set_metadata():
+def test_pdf_set_metadata() -> None:
     fileobj = io.BytesIO()
     with cairo.PDFSurface(fileobj, 128, 128) as surface:
         surface.set_metadata(cairo.PDFMetadata.TITLE, "title")
@@ -210,7 +210,7 @@ def test_pdf_set_metadata():
 
 @pytest.mark.skipif(not hasattr(cairo.PDFSurface, "set_custom_metadata"),
                     reason="too old cairo")
-def test_pdf_set_custom_metadata():
+def test_pdf_set_custom_metadata() -> None:
     fileobj = io.BytesIO()
     with cairo.PDFSurface(fileobj, 128, 128) as surface:
         surface.set_custom_metadata("ISBN", "978-0123456789")
@@ -220,7 +220,7 @@ def test_pdf_set_custom_metadata():
 
 @pytest.mark.skipif(not hasattr(cairo.PDFSurface, "add_outline"),
                     reason="too old cairo")
-def test_pdf_add_outline():
+def test_pdf_add_outline() -> None:
     fileobj = io.BytesIO()
     with cairo.PDFSurface(fileobj, 128, 128) as surface:
         res = surface.add_outline(
@@ -231,7 +231,7 @@ def test_pdf_add_outline():
 
 @pytest.mark.skipif(not hasattr(cairo.PDFSurface, "set_thumbnail_size"),
                     reason="too old cairo")
-def test_pdf_set_thumbnail_size():
+def test_pdf_set_thumbnail_size() -> None:
     fileobj = io.BytesIO()
     with cairo.PDFSurface(fileobj, 128, 128) as surface:
         surface.set_thumbnail_size(10, 10)
@@ -243,7 +243,7 @@ def test_pdf_set_thumbnail_size():
 
 @pytest.mark.skipif(
     sysconfig.get_platform().startswith("win"), reason="msvc fixme")
-def test_pdf_surface():
+def test_pdf_surface() -> None:
     fd, fname = tempfile.mkstemp()
     os.close(fd)
     try:
@@ -252,27 +252,27 @@ def test_pdf_surface():
         os.unlink(fname)
 
     with pytest.raises(TypeError):
-        cairo.PDFSurface()
+        cairo.PDFSurface()  # type: ignore
 
     with pytest.raises((ValueError, TypeError)):
-        cairo.PDFSurface("\x00")
+        cairo.PDFSurface("\x00")  # type: ignore
 
     with pytest.raises(TypeError):
-        cairo.PDFSurface(object(), 100, 100)
+        cairo.PDFSurface(object(), 100, 100)  # type: ignore
 
 
-def test_svg_version_to_string():
+def test_svg_version_to_string() -> None:
     ver = cairo.SVGSurface.version_to_string(cairo.SVG_VERSION_1_1)
     assert ver and isinstance(ver, str)
     with pytest.raises(ValueError):
-        cairo.SVGSurface.version_to_string(-1)
+        cairo.SVGSurface.version_to_string(-1)  # type: ignore
     with pytest.raises(TypeError):
-        cairo.SVGSurface.version_to_string(object())
+        cairo.SVGSurface.version_to_string(object())  # type: ignore
 
 
 @pytest.mark.skipif(not hasattr(cairo.SVGSurface, "get_document_unit"),
                     reason="too old cairo")
-def test_svg_surface_get_document_unit():
+def test_svg_surface_get_document_unit() -> None:
     with cairo.SVGSurface(None, 10, 10) as surface:
         # https://gitlab.freedesktop.org/cairo/cairo/-/issues/545
         assert surface.get_document_unit() in [cairo.SVGUnit.PT, cairo.SVGUnit.USER]
@@ -284,102 +284,102 @@ def test_svg_surface_get_document_unit():
         surface.set_document_unit(cairo.SVGUnit.PX)
 
 
-def test_svg_surface_restrict_to_version():
+def test_svg_surface_restrict_to_version() -> None:
     surface = cairo.SVGSurface(None, 10, 10)
     surface.restrict_to_version(cairo.SVG_VERSION_1_1)
     surface.finish()
     with pytest.raises(cairo.Error):
         surface.restrict_to_version(cairo.SVG_VERSION_1_2)
     with pytest.raises(TypeError):
-        surface.restrict_to_version(object())
+        surface.restrict_to_version(object())  # type: ignore
 
 
 @pytest.mark.skipif(
     sysconfig.get_platform().startswith("win"), reason="msvc fixme")
-def test_pdf_surface_restrict_to_version():
+def test_pdf_surface_restrict_to_version() -> None:
     surface = cairo.PDFSurface(None, 10, 10)
     surface.restrict_to_version(cairo.PDF_VERSION_1_4)
     surface.finish()
     with pytest.raises(cairo.Error):
         surface.restrict_to_version(cairo.PDF_VERSION_1_5)
     with pytest.raises(TypeError):
-        surface.restrict_to_version(object())
+        surface.restrict_to_version(object())  # type: ignore
 
 
-def test_pdf_version_to_string():
+def test_pdf_version_to_string() -> None:
     ver = cairo.PDFSurface.version_to_string(cairo.PDF_VERSION_1_4)
     assert ver and isinstance(ver, str)
     with pytest.raises(ValueError):
-        cairo.PDFSurface.version_to_string(-1)
+        cairo.PDFSurface.version_to_string(-1)  # type: ignore
     with pytest.raises(TypeError):
-        cairo.PDFSurface.version_to_string(object())
+        cairo.PDFSurface.version_to_string(object())  # type: ignore
 
 
-def test_ps_surface_error():
+def test_ps_surface_error() -> None:
     cairo.PSSurface(io.BytesIO(), 10, 10)
     with pytest.raises(TypeError):
-        cairo.PSSurface(object(), 10, 10)
+        cairo.PSSurface(object(), 10, 10)  # type: ignore
     with pytest.raises(TypeError):
-        cairo.PSSurface(io.StringIO(), 10, 10)
+        cairo.PSSurface(io.StringIO(), 10, 10)  # type: ignore
 
 
-def test_ps_surface_misc():
+def test_ps_surface_misc() -> None:
     surface = cairo.PSSurface(None, 10, 10)
     surface.dsc_begin_page_setup()
     surface.dsc_begin_setup()
 
 
-def test_ps_surface_dsc_comment():
+def test_ps_surface_dsc_comment() -> None:
     surface = cairo.PSSurface(None, 10, 10)
     surface.dsc_comment("%%Title: My excellent document")
     with pytest.raises(cairo.Error):
         surface.dsc_comment("")
     with pytest.raises(TypeError):
-        surface.dsc_comment(object())
+        surface.dsc_comment(object())  # type: ignore
 
 
-def test_ps_get_eps():
+def test_ps_get_eps() -> None:
     surface = cairo.PSSurface(None, 10, 10)
     assert isinstance(surface.get_eps(), bool)
     surface.set_eps(True)
     assert surface.get_eps()
     with pytest.raises(TypeError):
-        surface.set_eps(object())
+        surface.set_eps(object())  # type: ignore
 
 
-def test_ps_set_size():
+def test_ps_set_size() -> None:
     surface = cairo.PSSurface(None, 10, 10)
     surface.set_size(10, 10)
     with pytest.raises(TypeError):
-        surface.set_size(10, object())
+        surface.set_size(10, object())  # type: ignore
 
 
-def test_ps_restrict_to_level():
+def test_ps_restrict_to_level() -> None:
     surface = cairo.PSSurface(None, 10, 10)
     surface.restrict_to_level(cairo.PSLevel.LEVEL_2)
     with pytest.raises(TypeError):
-        surface.restrict_to_level(object())
+        surface.restrict_to_level(object())  # type: ignore
 
 
 @pytest.mark.skipif(
     sysconfig.get_platform().startswith("win"), reason="msvc fixme")
-def test_ps_surface_level_to_string():
+def test_ps_surface_level_to_string() -> None:
     level_id = cairo.PSSurface.level_to_string(cairo.PS_LEVEL_2)
     assert isinstance(level_id, str)
     assert cairo.PSSurface.ps_level_to_string(cairo.PS_LEVEL_2) == level_id
     with pytest.raises(ValueError):
-        cairo.PSSurface.level_to_string(-1)
+        cairo.PSSurface.level_to_string(-1)  # type: ignore
     with pytest.raises(TypeError):
-        cairo.PSSurface.level_to_string(object())
+        cairo.PSSurface.level_to_string(object())  # type: ignore
 
 
-def test_ps_surface_get_levels():
+def test_ps_surface_get_levels() -> None:
     levels = cairo.PSSurface.get_levels()
     assert isinstance(levels, list)
     assert all(isinstance(v, cairo.PSLevel) for v in levels)
 
 
-def test_ps_surface():
+def test_ps_surface() -> None:
     assert isinstance(cairo.PSSurface(None, 10, 10), cairo.PSSurface)
 
     fd, fname = tempfile.mkstemp()
@@ -390,16 +390,16 @@ def test_ps_surface():
         os.unlink(fname)
 
     with pytest.raises(TypeError):
-        cairo.PSSurface()
+        cairo.PSSurface()  # type: ignore
 
     with pytest.raises((ValueError, TypeError)):
         cairo.PSSurface("\x00", 100, 100)
 
     with pytest.raises(TypeError):
-        cairo.PSSurface(object(), 100, 100)
+        cairo.PSSurface(object(), 100, 100)  # type: ignore
 
 
-def test_scg_surface():
+def test_scg_surface() -> None:
     fd, fname = tempfile.mkstemp()
     os.close(fd)
     try:
@@ -408,38 +408,37 @@ def test_scg_surface():
         os.unlink(fname)
 
     with pytest.raises(TypeError):
-        cairo.SVGSurface()
+        cairo.SVGSurface()  # type: ignore
 
     with pytest.raises((ValueError, TypeError)):
         cairo.SVGSurface("\x00", 10, 10)
 
     with pytest.raises(TypeError):
-        cairo.SVGSurface(object(), 100, 100)
+        cairo.SVGSurface(object(), 100, 100)  # type: ignore
 
 
-def test_svg_surface_get_versions():
+def test_svg_surface_get_versions() -> None:
     versions = cairo.SVGSurface.get_versions()
     assert isinstance(versions, list)
     assert all(isinstance(v, cairo.SVGVersion) for v in versions)
 
 
-def test_surface_get_device_scale():
+def test_surface_get_device_scale() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     device_scale = surface.get_device_scale()
     assert all(isinstance(s, float) for s in device_scale)
 
 
-def test_surface_set_device_scale():
+def test_surface_set_device_scale() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
-    ret = surface.set_device_scale(5.0, 3.0)
-    assert ret is None
+    surface.set_device_scale(5.0, 3.0)
 
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 100, 100)
     with pytest.raises(cairo.Error):
         surface.set_device_scale(1, 0)
 
     with pytest.raises(TypeError):
-        surface.set_device_scale(1, object())
+        surface.set_device_scale(1, object())  # type: ignore
 
     surface.set_device_scale(sys.float_info.max, -sys.float_info.max)
     assert surface.get_device_scale() == (sys.float_info.max, -sys.float_info.max)
@@ -449,7 +448,7 @@ def test_surface_set_device_scale():
     assert excinfo.value.status == cairo.Status.INVALID_MATRIX
 
 
-def test_surface_create_for_rectangle():
+def test_surface_create_for_rectangle() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 100, 100)
     new = surface.create_for_rectangle(0, 0, 10, 10)
     assert new
@@ -464,7 +463,7 @@ def test_surface_create_for_rectangle():
     assert excinfo.value.status == cairo.STATUS_INVALID_SIZE
 
     with pytest.raises(TypeError):
-        surface.create_for_rectangle(0, 0, 10, object())
+        surface.create_for_rectangle(0, 0, 10, object())  # type: ignore
 
     surface.create_for_rectangle(
         sys.float_info.max, sys.float_info.max,
@@ -475,7 +474,7 @@ def test_surface_create_for_rectangle():
         sys.float_info.min, sys.float_info.min)
 
 
-def test_surface_create_similar_image():
+def test_surface_create_similar_image() -> None:
     surface = cairo.PDFSurface(None, 1, 1)
     image = surface.create_similar_image(cairo.FORMAT_ARGB32, 24, 42)
     assert image
@@ -485,10 +484,10 @@ def test_surface_create_similar_image():
     assert image.get_height() == 42
     surface = cairo.PDFSurface(None, 1, 1)
     with pytest.raises(TypeError):
-        surface.create_similar_image(cairo.FORMAT_ARGB32, 24, object())
+        surface.create_similar_image(cairo.FORMAT_ARGB32, 24, object())  # type: ignore
 
 
-def test_surface_get_set_mime_data():
+def test_surface_get_set_mime_data() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_RGB24, 1, 1)
     assert surface.get_mime_data("foo") is None
     assert surface.get_mime_data(cairo.MIME_TYPE_JPEG) is None
@@ -499,21 +498,23 @@ def test_surface_get_set_mime_data():
     assert surface.get_mime_data("foo") is None
 
     surface.set_mime_data(cairo.MIME_TYPE_JPEG, b"\x00quux\x00")
-    assert surface.get_mime_data(cairo.MIME_TYPE_JPEG)[:] == b"\x00quux\x00"
+    data = surface.get_mime_data(cairo.MIME_TYPE_JPEG)
+    assert data is not None
+    assert data[:] == b"\x00quux\x00"
     surface.set_mime_data(cairo.MIME_TYPE_JPEG, None)
     assert surface.get_mime_data(cairo.MIME_TYPE_JPEG) is None
     with pytest.raises(TypeError):
-        surface.set_mime_data(cairo.MIME_TYPE_JPEG, object())
+        surface.set_mime_data(cairo.MIME_TYPE_JPEG, object())  # type: ignore
     with pytest.raises(TypeError):
-        surface.get_mime_data(object())
+        surface.get_mime_data(object())  # type: ignore
 
 
-def test_supports_mime_type():
+def test_supports_mime_type() -> None:
     surface = cairo.PDFSurface(None, 3, 3)
     assert surface.supports_mime_type(cairo.MIME_TYPE_JPEG)
     assert not surface.supports_mime_type("nope")
     with pytest.raises(TypeError):
-        surface.supports_mime_type(object())
+        surface.supports_mime_type(object())  # type: ignore
 
 
 def test_image_surface_create_for_data_array():
@@ -541,7 +542,7 @@ def test_image_surface_create_for_data_array():
     os.unlink(filename)
 
 
-def test_image_surface_write_to_png_filename_and_obj_compare():
+def test_image_surface_write_to_png_filename_and_obj_compare() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 128, 128)
     fd, filename = tempfile.mkstemp(prefix='pycairo_', suffix='.png')
     os.close(fd)
@@ -556,7 +557,7 @@ def test_image_surface_write_to_png_filename_and_obj_compare():
     os.unlink(filename)
 
 
-def test_image_surface_png_obj_roundtrip():
+def test_image_surface_png_obj_roundtrip() -> None:
     fileobj = io.BytesIO()
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 128, 128)
     surface.write_to_png(fileobj)
@@ -564,16 +565,16 @@ def test_image_surface_png_obj_roundtrip():
     new_surface = cairo.ImageSurface.create_from_png(fileobj)
     assert surface.get_data() == new_surface.get_data()
     with pytest.raises(TypeError):
-        cairo.ImageSurface.create_from_png()
+        cairo.ImageSurface.create_from_png()  # type: ignore
     with pytest.raises((ValueError, TypeError)):
         cairo.ImageSurface.create_from_png("\x00")
     with pytest.raises(TypeError):
-        cairo.ImageSurface.create_from_png(object())
+        cairo.ImageSurface.create_from_png(object())  # type: ignore
     with pytest.raises(TypeError):
-        cairo.ImageSurface.create_from_png(io.StringIO())
+        cairo.ImageSurface.create_from_png(io.StringIO())  # type: ignore
 
 
-def test_image_surface_png_file_roundtrip():
+def test_image_surface_png_file_roundtrip() -> None:
     fd, filename = tempfile.mkstemp(prefix='pycairo_', suffix='.png')
     os.close(fd)
 
@@ -585,15 +586,15 @@ def test_image_surface_png_file_roundtrip():
     os.unlink(filename)
 
 
-def test_image_surface_write_to_png_error():
+def test_image_surface_write_to_png_error() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 128, 128)
     with pytest.raises(TypeError):
-        surface.write_to_png(42)
+        surface.write_to_png(42)  # type: ignore
     with pytest.raises((ValueError, TypeError)):
         surface.write_to_png("\x00")
 
 
-def test_surface_from_stream_closed_before_finished():
+def test_surface_from_stream_closed_before_finished() -> None:
     for _ in [cairo.PDFSurface, cairo.PSSurface, cairo.SVGSurface]:
         fileobj = io.BytesIO()
         surface = cairo.PDFSurface(fileobj, 128, 128)
@@ -602,7 +603,7 @@ def test_surface_from_stream_closed_before_finished():
             surface.finish()
 
 
-def test_script_surface():
+def test_script_surface() -> None:
     f = io.BytesIO()
     dev = cairo.ScriptDevice(f)
     surface = cairo.ScriptSurface(dev, cairo.Content.COLOR_ALPHA, 42, 10)
@@ -612,10 +613,10 @@ def test_script_surface():
     assert b"42" in f.getvalue()
     assert b"paint" in f.getvalue()
     with pytest.raises(TypeError):
-        cairo.ScriptSurface()
+        cairo.ScriptSurface()  # type: ignore
 
 
-def test_script_device_device_ref():
+def test_script_device_device_ref() -> None:
     f = io.BytesIO()
     dev = cairo.ScriptDevice(f)
     surface = cairo.ScriptSurface(dev, cairo.Content.COLOR_ALPHA, 42, 10)
@@ -624,14 +625,14 @@ def test_script_device_device_ref():
         surface.get_device()
 
 
-def test_script_surface_create_for_target():
+def test_script_surface_create_for_target() -> None:
     # paint the script proxy
     f = io.BytesIO()
     dev = cairo.ScriptDevice(f)
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     script = cairo.ScriptSurface.create_for_target(dev, surface)
     with pytest.raises(TypeError):
-        cairo.ScriptSurface.create_for_target(dev, object())
+        cairo.ScriptSurface.create_for_target(dev, object())  # type: ignore
     assert isinstance(script, cairo.ScriptSurface)
     ctx = cairo.Context(script)
     ctx.set_source_rgb(0.25, 0.5, 1.0)
@@ -642,14 +643,14 @@ def test_script_surface_create_for_target():
 
     # check if the result is the same
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
-    ctx = cairo.Context(surface)
-    ctx.set_source_rgb(0.25, 0.5, 1.0)
-    ctx.paint()
+    ctx2 = cairo.Context(surface)
+    ctx2.set_source_rgb(0.25, 0.5, 1.0)
+    ctx2.paint()
     surface.flush()
     assert bytes(surface.get_data()) == image_data
 
 
-def test_misc():
+def test_misc() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     surface.copy_page()
     surface.mark_dirty()
@@ -657,66 +658,66 @@ def test_misc():
 
 
 @pytest.fixture
-def surface():
+def surface() -> cairo.Surface:
     return cairo.ImageSurface(cairo.Format.ARGB32, 10, 10)
 
 
 @pytest.fixture
-def image_surface():
+def image_surface() -> cairo.ImageSurface:
     return cairo.ImageSurface(cairo.Format.ARGB32, 10, 10)
 
 
-def test_create_similar(surface):
+def test_create_similar(surface: cairo.Surface) -> None:
     similar = surface.create_similar(cairo.Content.COLOR, 10, 10)
     assert isinstance(similar, cairo.Surface)
     with pytest.raises(TypeError):
-        surface.create_similar()
+        surface.create_similar()  # type: ignore
 
 
-def test_get_device_offset(surface):
+def test_get_device_offset(surface: cairo.Surface) -> None:
     surface.set_device_offset(1, 1)
     assert surface.get_device_offset() == (1, 1)
     with pytest.raises(TypeError):
-        surface.set_device_offset(1, object())
+        surface.set_device_offset(1, object())  # type: ignore
 
     surface.set_device_offset(sys.float_info.max, -sys.float_info.max)
     assert surface.get_device_offset() == (sys.float_info.max, -sys.float_info.max)
 
 
-def test_get_fallback_resolution(surface):
+def test_get_fallback_resolution(surface: cairo.Surface) -> None:
     surface.set_fallback_resolution(42, 42)
     assert surface.get_fallback_resolution() == (42, 42)
     with pytest.raises(TypeError):
-        surface.set_fallback_resolution(42, object())
+        surface.set_fallback_resolution(42, object())  # type: ignore
 
 
-def test_mark_dirty_rectangle(surface):
+def test_mark_dirty_rectangle(surface: cairo.Surface) -> None:
     surface.mark_dirty_rectangle(0, 0, 10, 10)
     with pytest.raises(TypeError):
-        surface.mark_dirty_rectangle(0, 0, 10, object())
+        surface.mark_dirty_rectangle(0, 0, 10, object())  # type: ignore
 
 
-def test_write_to_png(image_surface):
+def test_write_to_png(image_surface: cairo.ImageSurface) -> None:
     with pytest.raises(TypeError):
-        image_surface.write_to_png()
+        image_surface.write_to_png()  # type: ignore
 
     with pytest.raises(TypeError):
-        image_surface.write_to_png(io.StringIO())
+        image_surface.write_to_png(io.StringIO())  # type: ignore
 
     with pytest.raises((ValueError, TypeError)) as excinfo:
         image_surface.write_to_png("\x00")
     excinfo.match(r'.* (null|NUL) .*')
 
     with pytest.raises(TypeError):
-        image_surface.write_to_png(object())
+        image_surface.write_to_png(object())  # type: ignore
 
 
-def test_image_surface():
+def test_image_surface() -> None:
     with pytest.raises(TypeError):
-        cairo.ImageSurface(cairo.FORMAT_ARGB32, 3, object())
+        cairo.ImageSurface(cairo.FORMAT_ARGB32, 3, object())  # type: ignore
 
 
-def test_image_surface_create_for_data():
+def test_image_surface_create_for_data() -> None:
     format_ = cairo.FORMAT_ARGB32
     surface = cairo.ImageSurface(format_, 3, 3)
     ctx = cairo.Context(surface)
@@ -741,10 +742,10 @@ def test_image_surface_create_for_data():
     assert excinfo.value.status == cairo.STATUS_INVALID_STRIDE
 
     with pytest.raises(TypeError):
-        cairo.ImageSurface.create_for_data(buf, format_, 3, object())
+        cairo.ImageSurface.create_for_data(buf, format_, 3, object())  # type: ignore
 
 
-def test_image_surface_get_data_finished():
+def test_image_surface_get_data_finished() -> None:
     surface = cairo.ImageSurface(cairo.Format.ARGB32, 30, 30)
     surface.finish()
     with pytest.raises(cairo.Error) as excinfo:
@@ -752,7 +753,7 @@ def test_image_surface_get_data_finished():
     assert excinfo.value.status == cairo.Status.SURFACE_FINISHED
 
 
-def test_image_surface_buffer_get_data_finished():
+def test_image_surface_buffer_get_data_finished() -> None:
     width, height = 6, 4
     buffer = bytearray(width * height * 4)
     surface = cairo.ImageSurface.create_for_data(
@@ -777,25 +778,25 @@ def test_image_surface_png_get_data_finished():
     assert excinfo.value.status == cairo.Status.SURFACE_FINISHED
 
 
-def test_image_surface_stride_for_width():
+def test_image_surface_stride_for_width() -> None:
     v = cairo.ImageSurface.format_stride_for_width(cairo.Format.ARGB32, 10)
     assert v == 40
 
     with pytest.raises(TypeError):
         cairo.ImageSurface.format_stride_for_width(
-            cairo.Format.ARGB32, object())
+            cairo.Format.ARGB32, object())  # type: ignore
 
 
-def test_image_surface_get_stride(image_surface):
+def test_image_surface_get_stride(image_surface: cairo.ImageSurface) -> None:
     assert image_surface.get_stride() == 40
 
 
-def test_recording_surface():
+def test_recording_surface() -> None:
     with pytest.raises(TypeError):
-        cairo.RecordingSurface(cairo.CONTENT_COLOR, object())
+        cairo.RecordingSurface(cairo.CONTENT_COLOR, object())  # type: ignore
 
     with pytest.raises(TypeError):
-        cairo.RecordingSurface()
+        cairo.RecordingSurface()  # type: ignore
 
     surface = cairo.RecordingSurface(cairo.CONTENT_COLOR, None)
     assert surface.ink_extents() == (0.0, 0.0, 0.0, 0.0)

--- a/tests/test_textcluster.py
+++ b/tests/test_textcluster.py
@@ -4,12 +4,12 @@ import cairo
 import pytest
 
 
-def test_type():
-    assert cairo.TextCluster
+def test_type() -> None:
+    assert hasattr(cairo, "TextCluster")
     assert issubclass(cairo.TextCluster, tuple)
 
     with pytest.raises(TypeError):
-        cairo.TextCluster()
+        cairo.TextCluster()  # type: ignore
 
     r = cairo.TextCluster(2, 1)
     assert hash(r) == hash(cairo.TextCluster(2, 1))
@@ -21,7 +21,7 @@ def test_type():
     assert r.num_glyphs == 1
 
     with pytest.raises(AttributeError):
-        assert r.z
+        assert r.z  # type: ignore
 
     assert repr(r) == "cairo.TextCluster(num_bytes=2, num_glyphs=1)"
     assert str(r) == "cairo.TextCluster(num_bytes=2, num_glyphs=1)"
@@ -31,7 +31,7 @@ def test_type():
     assert cairo.TextCluster.num_glyphs
 
 
-def test_text_cluster_limits():
+def test_text_cluster_limits() -> None:
     max_int = 2 ** (ctypes.sizeof(ctypes.c_int()) * 8 - 1) - 1
     min_int = -max_int - 1
 

--- a/tests/test_textextents.py
+++ b/tests/test_textextents.py
@@ -4,12 +4,12 @@ import cairo
 import pytest
 
 
-def test_type():
-    assert cairo.TextExtents
+def test_type() -> None:
+    assert hasattr(cairo, "TextExtents")
     assert issubclass(cairo.TextExtents, tuple)
 
     with pytest.raises(TypeError):
-        cairo.TextExtents()
+        cairo.TextExtents()  # type: ignore
 
     r = cairo.TextExtents(0.0, 0.5, 0.25, 0.75, 0.5, 0.125)
     assert hash(r) == hash(cairo.TextExtents(0.0, 0.5, 0.25, 0.75, 0.5, 0.125))
@@ -23,7 +23,7 @@ def test_type():
     assert r.y_bearing == 0.5
 
     with pytest.raises(AttributeError):
-        assert r.z
+        assert r.z  # type: ignore
 
     assert repr(r) == \
         "cairo.TextExtents(x_bearing=0.0, y_bearing=0.5, " \
@@ -40,7 +40,7 @@ def test_type():
     assert cairo.TextExtents.y_advance
 
 
-def test_methods():
+def test_methods() -> None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
     context = cairo.Context(surface)
 
@@ -58,7 +58,7 @@ def test_methods():
     assert isinstance(extents, cairo.TextExtents)
 
 
-def test_text_extents_limits():
+def test_text_extents_limits() -> None:
     max_val = sys.float_info.max
     min_val = sys.float_info.min
 


### PR DESCRIPTION
Enable for tests where it's easy or where ignoring some type errors is expected.

Some issues found along the way:

* Surface.set_mime_data: missing Optional
* SVGSurface/PDFSurface/PSSurface: missing Optional
* RecordingSurface: missing Optional
* Region: default rectangle to empty list (in theory it's a different code path internally, but the result is the same)