### PR TITLE
Surface: release the create_for_data() input buffer on finish()

### DIFF
--- a/cairo/surface.c
+++ b/cairo/surface.c
@@ -225,6 +225,12 @@ static PyObject *
 surface_finish (PycairoSurface *o, PyObject *ignored) {
   cairo_surface_finish (o->surface);
   Py_CLEAR(o->base);
+
+  /* After an image surface is finished it won't access the buffer and
+  we can release it */
+  cairo_surface_set_user_data(
+    o->surface, &surface_buffer_view_key, NULL, NULL);
+
   RETURN_NULL_IF_CAIRO_SURFACE_ERROR(o->surface);
   Py_RETURN_NONE;
 }

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -808,3 +808,16 @@ def test_format_rgbf():
     assert surface.get_format() == cairo.Format.RGB96F
     surface = cairo.ImageSurface(cairo.Format.RGBA128F, 3, 3)
     assert surface.get_format() == cairo.Format.RGBA128F
+
+
+def test_image_surface_release_on_finish() -> None:
+    width, height = 6, 4
+    buffer = bytearray(width * height * 4)
+    mem = memoryview(buffer)
+    surface = cairo.ImageSurface.create_for_data(
+        mem, cairo.FORMAT_ARGB32, width, height, width * 4
+    )
+    surface.finish()
+    # after the surface is finished, there should be nothing exported from the
+    # memoryview anymore
+    mem.release()


### PR DESCRIPTION
In case a surface is created via create_for_data() we get a buffer from the input for passing to cairo. Once the surface is finished though, cairo should no longer read/write to it and the buffer is no longer really needed. Up until now we only released the buffer once the surface was destroyed, which means after the Python wrapper was GCed, which is hard to control from Python if one wants to release resources.

This changes the buffer release to also happen on finish(). Note that this only works if finish() is called from Python since we don't notice otherwise.

This is also related to https://github.com/pygobject/pycairo/pull/400 which made get_data() raise in case the surface is finished, to avoid returning freed data with this on top.

Fixes #392