### PR TITLE
Deprecate the num_glyphs parameter everywhere

### DIFF
--- a/cairo/context.c
+++ b/cairo/context.c
@@ -514,6 +514,12 @@ pycairo_glyph_extents (PycairoContext *o, PyObject *args) {
 			 &py_object, &num_glyphs))
     return NULL;
 
+  if (PyTuple_Size (args) > 1) {
+    PyErr_WarnEx (PyExc_DeprecationWarning,
+                  "The num_glyphs parameter to Context.glyph_extents is deprecated",
+                  1);
+  }
+
   glyphs = _PycairoGlyphs_AsGlyphs (py_object, &num_glyphs);
   if (glyphs == NULL)
     return NULL;
@@ -537,6 +543,12 @@ pycairo_glyph_path (PycairoContext *o, PyObject *args) {
   if (!PyArg_ParseTuple (args, "O|i:Context.glyph_path",
 			 &py_object, &num_glyphs))
     return NULL;
+
+  if (PyTuple_Size (args) > 1) {
+    PyErr_WarnEx (PyExc_DeprecationWarning,
+                  "The num_glyphs parameter to Context.glyph_path is deprecated",
+                  1);
+  }
 
   glyphs = _PycairoGlyphs_AsGlyphs (py_object, &num_glyphs);
   if (glyphs == NULL)
@@ -1131,6 +1143,12 @@ pycairo_show_glyphs (PycairoContext *o, PyObject *args) {
   if (!PyArg_ParseTuple (args, "O|i:Context.show_glyphs",
 			 &py_object, &num_glyphs))
     return NULL;
+
+  if (PyTuple_Size (args) > 1) {
+    PyErr_WarnEx (PyExc_DeprecationWarning,
+                  "The num_glyphs parameter to Context.show_glyphs is deprecated",
+                  1);
+  }
 
   glyphs = _PycairoGlyphs_AsGlyphs (py_object, &num_glyphs);
   if (glyphs == NULL)

--- a/cairo/font.c
+++ b/cairo/font.c
@@ -487,6 +487,12 @@ scaled_font_glyph_extents (PycairoScaledFont *o, PyObject *args) {
       &py_object, &num_glyphs))
     return NULL;
 
+  if (PyTuple_Size (args) > 1) {
+    PyErr_WarnEx (PyExc_DeprecationWarning,
+                  "The num_glyphs parameter to ScaledFont.glyph_extents is deprecated",
+                  1);
+  }
+
   glyphs = _PycairoGlyphs_AsGlyphs (py_object, &num_glyphs);
   if (glyphs == NULL)
     return NULL;

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -465,8 +465,9 @@ def test_show_glyphs(context: cairo.Context) -> None:
     with pytest.raises(TypeError):
         context.show_glyphs(object())  # type: ignore
 
-    # the num_glyphs argument is not annotated
-    context.show_glyphs([], 0)  # type: ignore
+    with pytest.warns(DeprecationWarning, match="num_glyphs.*show_glyphs"):
+        # the num_glyphs argument is not annotated
+        context.show_glyphs([], 0)  # type: ignore
 
 
 def test_show_text(context: cairo.Context) -> None:

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -222,6 +222,12 @@ def test_scaled_font_text_extents(scaled_font: cairo.ScaledFont) -> None:
 
 
 def test_scaled_font_glyph_extents(scaled_font: cairo.ScaledFont) -> None:
+
+    scaled_font.glyph_extents([cairo.Glyph(0, 0.5, 0.25)])
+
+    with pytest.warns(DeprecationWarning, match="num_glyphs.*glyph_extents"):
+        scaled_font.glyph_extents([], 0)  # type: ignore
+
     with pytest.raises(TypeError):
         scaled_font.glyph_extents(object())  # type: ignore
     with pytest.raises(TypeError):

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -51,6 +51,12 @@ def test_context() -> None:
     context.glyph_path([g])
     context.show_glyphs([cairo.Glyph(0, 0, 0)])
 
+    with pytest.warns(DeprecationWarning, match="num_glyphs.*glyph_extents"):
+        context.glyph_extents([], 0)  # type: ignore
+
+    with pytest.warns(DeprecationWarning, match="num_glyphs.*glyph_path"):
+        context.glyph_path([], 0)  # type: ignore
+
     with pytest.raises(TypeError):
         context.glyph_path([object()])  # type: ignore
 


### PR DESCRIPTION
This deprecates the num_glyphs parameter for:

* Context.glyph_extents
* Context.glyph_path
* Context.show_glyphs
* ScaledFont.glyph_extents

It could be used to limit the length of the passed sequence to be considered, while being limited to the real length to the sequence, and also defaulting to the real length of the sequence.

This is just confusing since no other APIs work that way in pycairo. I never added them to the stubs, and they are also gone from the HTML docs since that was switched to be generated from the stubs.

Let's make this more official by emitting a deprecation warning when they are used at runtime. There are no plans to remove them though.