### PR TITLE
Path.__iter__: return PathDataType enums instead of ints

### DIFF
--- a/cairo/__init__.pyi
+++ b/cairo/__init__.pyi
@@ -142,7 +142,7 @@ class Path:
     See examples/warpedtext.py for example usage.
     """
 
-    def __iter__(self) -> Iterator[tuple[int, tuple[float, ...]]]:
+    def __iter__(self) -> Iterator[tuple[PathDataType, tuple[float, ...]]]:
         ...
 
     def __eq__(self, other: object) -> bool:

--- a/cairo/path.c
+++ b/cairo/path.c
@@ -264,6 +264,7 @@ static PyObject *
 pathiter_next(PycairoPathiter *it) {
   PycairoPath *pypath;
   cairo_path_t *path;
+  PyObject *path_data_type;
 
   assert(it != NULL);
   pypath = it->pypath;
@@ -279,19 +280,24 @@ pathiter_next(PycairoPathiter *it) {
 
     it->index += data[0].header.length;
 
+    path_data_type = CREATE_INT_ENUM(PathDataType, type);
+    if (path_data_type == NULL)
+      return NULL;
+
     switch (type) {
     case CAIRO_PATH_MOVE_TO:
     case CAIRO_PATH_LINE_TO:
-      return Py_BuildValue("(i(dd))", (int)type,
+      return Py_BuildValue("(N(dd))", path_data_type,
 			   data[1].point.x, data[1].point.y);
     case CAIRO_PATH_CURVE_TO:
-      return Py_BuildValue("(i(dddddd))", (int)type,
+      return Py_BuildValue("(N(dddddd))", path_data_type,
 			   data[1].point.x, data[1].point.y,
 			   data[2].point.x, data[2].point.y,
 			   data[3].point.x, data[3].point.y);
     case CAIRO_PATH_CLOSE_PATH:
-      return Py_BuildValue("i()", (int)type);
+      return Py_BuildValue("N()", path_data_type);
     default:
+      Py_DECREF(path_data_type);
       PyErr_SetString(PyExc_RuntimeError, "unknown CAIRO_PATH type");
       return NULL;
     }

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -63,11 +63,12 @@ def test_path_iter(context: cairo.Context) -> None:
     context.curve_to(0, 1, 2, 3, 4, 5)
     context.close_path()
     p = context.copy_path()
-    i = iter(p)
-    assert list(i) == [
-        (0, (1.0, 2.0)),
-        (1, (2.0, 3.0)),
-        (2, (0.0, 1.0, 2.0, 3.0, 4.0, 5.0)),
-        (3, ()),
-        (0, (1.0, 2.0)),
+    items = list(iter(p))
+    assert isinstance(items[0][0], cairo.PathDataType)
+    assert items == [
+        (cairo.PathDataType.MOVE_TO, (1.0, 2.0)),
+        (cairo.PathDataType.LINE_TO, (2.0, 3.0)),
+        (cairo.PathDataType.CURVE_TO, (0.0, 1.0, 2.0, 3.0, 4.0, 5.0)),
+        (cairo.PathDataType.CLOSE_PATH, ()),
+        (cairo.PathDataType.MOVE_TO, (1.0, 2.0)),
     ]


### PR DESCRIPTION
This was missed when converting all the enum return values to enums back with 1.13. The first element in the path items are PathDataType and not int, so convert them.

PathDataType is subclass of int, so this shouldn't break anything.