### PR TITLE
Fix pygame image format everywhere

### DIFF
--- a/docs/tutorial/pygame.rst
+++ b/docs/tutorial/pygame.rst
@@ -6,7 +6,7 @@ https://www.pygame.org
 Pygame & ImageSurface
 ---------------------
 
-Creating a pygame.image from an ImageSurface:
+Creating a pygame.image from an ImageSurface (requires pygame 2.1.3 or later):
 
 .. code:: python
 
@@ -16,4 +16,4 @@ Creating a pygame.image from an ImageSurface:
     width, height = 255, 255
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
     buf = surface.get_data()
-    image = pygame.image.frombuffer(buf, (width, height), "ARGB")
+    image = pygame.image.frombuffer(buf, (width, height), "BGRA")

--- a/examples/pygame-demo.py
+++ b/examples/pygame-demo.py
@@ -10,14 +10,28 @@ import pygame
 
 
 def draw(surface):
-    x, y, radius = (250, 250, 200)
+    # Draw three 50% transparent circles: red, green, and blue on a white background
     ctx = cairo.Context(surface)
-    ctx.set_line_width(15)
-    ctx.arc(x, y, radius, 0, 2.0 * math.pi)
-    ctx.set_source_rgb(0.8, 0.8, 0.8)
-    ctx.fill_preserve()
+
     ctx.set_source_rgb(1, 1, 1)
-    ctx.stroke()
+    ctx.paint()
+
+    width, height = 500, 500
+    center_x, center_y = width / 2, height / 2
+    radius = 120
+    offset = 80
+
+    ctx.set_source_rgba(1, 0, 0, 0.5)
+    ctx.arc(center_x - offset, center_y - offset, radius, 0, 2.0 * math.pi)
+    ctx.fill()
+
+    ctx.set_source_rgba(0, 1, 0, 0.5)
+    ctx.arc(center_x + offset, center_y - offset, radius, 0, 2.0 * math.pi)
+    ctx.fill()
+
+    ctx.set_source_rgba(0, 0, 1, 0.5)
+    ctx.arc(center_x, center_y + offset, radius, 0, 2.0 * math.pi)
+    ctx.fill()
 
 
 def input(events):
@@ -40,7 +54,7 @@ def main():
 
     # Create PyGame surface from Cairo Surface
     buf = surface.get_data()
-    image = pygame.image.frombuffer(buf, (width, height), "ARGB")
+    image = pygame.image.frombuffer(buf, (width, height), "BGRA")
     # Tranfer to Screen
     screen.blit(image, (0, 0))
     pygame.display.flip()

--- a/tests/test_surface_pygame.py
+++ b/tests/test_surface_pygame.py
@@ -1,12 +1,13 @@
 import cairo
 import pytest
 
-pygame = pytest.importorskip("pygame")
+# 2.1.3+ required for "BGRA" format
+pygame = pytest.importorskip("pygame", minversion="2.1.3")
 
 
 def test_image_surface_to_pygame_image() -> None:
     width, height = 100, 100
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
     buf = surface.get_data()
-    image = pygame.image.frombuffer(buf, (width, height), "ARGB")
+    image = pygame.image.frombuffer(buf, (width, height), "BGRA")
     assert image


### PR DESCRIPTION
* FORMAT_ARGB32 is equivalent to BGRA in pygame and not ARGB.
* BGRA support in pygame was added with 2.1.3 via https://github.com/pygame/pygame/pull/3342
* Update pygame example to use more colors and alpha to verify
* Bump the pygame requirements for the tests
* Adjust the docs and note the pygame version requirement

Fixes #247