### PR TITLE
get_data(): emit a DeprecationWarning for starters instead of raising

### DIFF
--- a/cairo/surface.c
+++ b/cairo/surface.c
@@ -1014,7 +1014,12 @@ image_surface_get_data (PycairoImageSurface *o, PyObject *ignored) {
   cairo_status_t status = cairo_status (ctx);
   cairo_destroy (ctx);
   if (Pycairo_Check_Status (status)) {
-    return NULL;
+    PyErr_Clear ();
+    PyErr_WarnEx (
+      PyExc_DeprecationWarning,
+      "Calling get_data() on a finished surface is deprecated and will raise in the future",
+      1
+    );
   }
 
   buffer = cairo_image_surface_get_data (surface);

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -741,9 +741,8 @@ def test_image_surface_create_for_data() -> None:
 def test_image_surface_get_data_finished() -> None:
     surface = cairo.ImageSurface(cairo.Format.ARGB32, 30, 30)
     surface.finish()
-    with pytest.raises(cairo.Error) as excinfo:
+    with pytest.warns(DeprecationWarning):
         surface.get_data()
-    assert excinfo.value.status == cairo.Status.SURFACE_FINISHED
 
 
 def test_image_surface_buffer_get_data_finished() -> None:
@@ -753,9 +752,8 @@ def test_image_surface_buffer_get_data_finished() -> None:
         buffer, cairo.FORMAT_ARGB32, width, height, width * 4
     )
     surface.finish()
-    with pytest.raises(cairo.Error) as excinfo:
+    with pytest.warns(DeprecationWarning):
         surface.get_data()
-    assert excinfo.value.status == cairo.Status.SURFACE_FINISHED
 
 
 def test_image_surface_png_get_data_finished() -> None:
@@ -766,9 +764,8 @@ def test_image_surface_png_get_data_finished() -> None:
     fileobj.seek(0)
     surface = cairo.ImageSurface.create_from_png(fileobj)
     surface.finish()
-    with pytest.raises(cairo.Error) as excinfo:
+    with pytest.warns(DeprecationWarning):
         surface.get_data()
-    assert excinfo.value.status == cairo.Status.SURFACE_FINISHED
 
 
 def test_image_surface_stride_for_width() -> None:


### PR DESCRIPTION
While in my testing I haven't found any users that might be affected by this edge case, I'm worried about fallout, so let's just warn for now.

In a future version we can upgrade the warning to an exception again.