### PR TITLE
Type stub: get_data() may return None

### DIFF
--- a/cairo/__init__.pyi
+++ b/cairo/__init__.pyi
@@ -2613,7 +2613,7 @@ class ImageSurface(Surface):
     .. versionadded:: 1.6
     """
 
-    def get_data(self) -> memoryview:
+    def get_data(self) -> memoryview | None:
         """
         :returns: a Python memoryview object for the data of the *ImageSurface*,
             for direct inspection or modification.


### PR DESCRIPTION
The data of a zero by zero `ImageSurface` is None. For example:

```
>>> import cairo
>>> print(cairo.ImageSurface(cairo.FORMAT_ARGB32, 0, 0).get_data())
None
```

This PR updates the type stub to reflect that. If it would be better to return a view into some dummy memory instead, let me know.