### PR TITLE
get_data(): Return empty memoryview for empty image

### DIFF
--- a/cairo/surface.c
+++ b/cairo/surface.c
@@ -998,6 +998,24 @@ image_surface_format_stride_for_width (PyObject *self, PyObject *args) {
   return PyLong_FromLong (cairo_format_stride_for_width (format, width));
 }
 
+/* Create a view into an empty bytes object.
+ * Corresponds to memoryview(b"") in Python.
+ * Returns NULL and sets an exception on error.
+ */
+static PyObject *
+create_empty_memoryview(void)
+{
+    PyObject *empty_bytes, *view;
+
+    empty_bytes = PyBytes_FromStringAndSize (NULL, 0);
+    if (!empty_bytes)
+        return NULL;
+
+    view = PyMemoryView_FromObject (empty_bytes);
+    Py_DECREF(empty_bytes);
+    return view;
+}
+
 static PyObject *
 image_surface_get_data (PycairoImageSurface *o, PyObject *ignored) {
   cairo_surface_t *surface;
@@ -1024,7 +1042,7 @@ image_surface_get_data (PycairoImageSurface *o, PyObject *ignored) {
 
   buffer = cairo_image_surface_get_data (surface);
   if (buffer == NULL) {
-    Py_RETURN_NONE;
+    return create_empty_memoryview();
   }
   height = cairo_image_surface_get_height (surface);
   stride = cairo_image_surface_get_stride (surface);

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -745,6 +745,12 @@ def test_image_surface_get_data_finished() -> None:
         surface.get_data()
 
 
+def test_image_surface_get_data_empty() -> None:
+    surface = cairo.ImageSurface(cairo.Format.ARGB32, 0, 0)
+    assert isinstance(surface.get_data(), memoryview)
+    assert len(surface.get_data()) == 0
+
+
 def test_image_surface_buffer_get_data_finished() -> None:
     width, height = 6, 4
     buffer = bytearray(width * height * 4)


### PR DESCRIPTION
A better solution instead of #417.

Before:

```
>>> import cairo
>>> print(cairo.ImageSurface(cairo.FORMAT_ARGB32, 0, 0).get_data())
None
```

After:

```
>>> import cairo
>>> print(cairo.ImageSurface(cairo.FORMAT_ARGB32, 0, 0).get_data())
<memory at 0x7f126b935000>
>>> bytes(cairo.ImageSurface(cairo.FORMAT_ARGB32, 0, 0).get_data())
b''
```