### PR TITLE
pyproject.toml: move to dependency-groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ stamp-h
 stamp-h1
 stamp-h.in
 poetry.lock
+uv.lock
 
 .vscode
 build-*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,30 +10,35 @@ urls = {Homepage = "https://pycairo.readthedocs.io", Source = "https://github.co
 dependencies = []
 
 [tool.poetry]
-requires-poetry = '>=2.0'
+requires-poetry = '>=2.2'
 package-mode = false
-
-[tool.poetry.group.dev.dependencies]
-pytest = "^8.3.0"
-mypy = {version = "1.15.0", markers = "platform_python_implementation != 'PyPy'"}
-flake8 = "^7.0.0"
-coverage = {extras = ["toml"], version = "^7.2.3"}
-meson-python = ">= 0.16.0"
 
 [tool.poetry.group.docs]
 optional = true
 
-[tool.poetry.group.docs.dependencies]
-Sphinx = "^7.4.0"
-sphinx-rtd-theme = "^3.0.0"
-sphinx-autobuild = "^2024.10.3"
-
 [tool.poetry.group.test-extras]
 optional = true
 
-[tool.poetry.group.test-extras.dependencies]
-pygame = "^2.1.3"
-numpy = "^2.0.0"
+[dependency-groups]
+dev = [
+    "pytest>=8.3.0,<9",
+    "mypy==1.15.0 ; platform_python_implementation != 'PyPy'",
+    "flake8>=7.0.0,<8",
+    "coverage[toml]>=7.2.3,<8",
+    "meson-python>= 0.16.0",
+]
+docs = [
+    "Sphinx>=7.4.0,<8",
+    "sphinx-rtd-theme>=3.0.0,<4",
+    "sphinx-autobuild>=2024.10.3,<2025",
+]
+test-extras = [
+    "pygame>=2.1.3,<3",
+    "numpy>=2.0.0,<3",
+]
+
+[tool.uv]
+package = false
 
 [tool.coverage.run]
 include = [


### PR DESCRIPTION
This bumps the minimum poetry version to 2.2.
With this both poetry and uv are supported for
package management during development.