### PR TITLE
build: add no-x11 option to disable X11 surface support

### DIFF
--- a/cairo/cairomodule.c
+++ b/cairo/cairomodule.c
@@ -96,12 +96,12 @@ static Pycairo_CAPI_t CAPI = {
   0,
   0,
 #endif
-#ifdef CAIRO_HAS_XCB_SURFACE
+#if defined(CAIRO_HAS_XCB_SURFACE) && !defined(PYCAIRO_NO_X11)
   &PycairoXCBSurface_Type,
 #else
   0,
 #endif
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if defined(CAIRO_HAS_XLIB_SURFACE) && !defined(PYCAIRO_NO_X11)
   &PycairoXlibSurface_Type,
 #else
   0,
@@ -242,11 +242,11 @@ static int exec_cairo(PyObject *m)
   if (PyType_Ready(&PycairoWin32PrintingSurface_Type) < 0)
     return -1;
 #endif
-#ifdef CAIRO_HAS_XCB_SURFACE
+#if defined(CAIRO_HAS_XCB_SURFACE) && !defined(PYCAIRO_NO_X11)
   if (PyType_Ready(&PycairoXCBSurface_Type) < 0)
     return -1;
 #endif
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if defined(CAIRO_HAS_XLIB_SURFACE) && !defined(PYCAIRO_NO_X11)
   if (PyType_Ready(&PycairoXlibSurface_Type) < 0)
     return -1;
 #endif
@@ -391,13 +391,13 @@ static int exec_cairo(PyObject *m)
       return -1;
 #endif
 
-#ifdef CAIRO_HAS_XCB_SURFACE
+#if defined(CAIRO_HAS_XCB_SURFACE) && !defined(PYCAIRO_NO_X11)
   if (PyModule_AddObjectRef(m, "XCBSurface",
                             (PyObject *)&PycairoXCBSurface_Type) < 0)
       return -1;
 #endif
 
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if defined(CAIRO_HAS_XLIB_SURFACE) && !defined(PYCAIRO_NO_X11)
   if (PyModule_AddObjectRef(m, "XlibSurface",
                             (PyObject *)&PycairoXlibSurface_Type) < 0)
       return -1;
@@ -501,14 +501,14 @@ static int exec_cairo(PyObject *m)
   if (PyModule_AddIntConstant(m, "HAS_WIN32_SURFACE", 0) < 0)
     return -1;
 #endif
-#ifdef CAIRO_HAS_XCB_SURFACE
+#if defined(CAIRO_HAS_XCB_SURFACE) && !defined(PYCAIRO_NO_X11)
   if (PyModule_AddIntConstant(m, "HAS_XCB_SURFACE", 1) < 0)
     return -1;
 #else
   if (PyModule_AddIntConstant(m, "HAS_XCB_SURFACE", 0) < 0)
     return -1;
 #endif
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if defined(CAIRO_HAS_XLIB_SURFACE) && !defined(PYCAIRO_NO_X11)
   if (PyModule_AddIntConstant(m, "HAS_XLIB_SURFACE", 1) < 0)
     return -1;
 #else

--- a/cairo/private.h
+++ b/cairo/private.h
@@ -157,11 +157,11 @@ extern PyTypeObject PycairoWin32Surface_Type;
 extern PyTypeObject PycairoWin32PrintingSurface_Type;
 #endif
 
-#ifdef CAIRO_HAS_XCB_SURFACE
+#if defined(CAIRO_HAS_XCB_SURFACE) && !defined(PYCAIRO_NO_X11)
 extern PyTypeObject PycairoXCBSurface_Type;
 #endif
 
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if defined(CAIRO_HAS_XLIB_SURFACE) && !defined(PYCAIRO_NO_X11)
 extern PyTypeObject PycairoXlibSurface_Type;
 #endif
 

--- a/cairo/surface.c
+++ b/cairo/surface.c
@@ -83,12 +83,12 @@ PycairoSurface_FromSurface (cairo_surface_t *surface, PyObject *base) {
     type = &PycairoWin32PrintingSurface_Type;
     break;
 #endif
-#ifdef CAIRO_HAS_XCB_SURFACE
+#if defined(CAIRO_HAS_XCB_SURFACE) && !defined(PYCAIRO_NO_X11)
   case CAIRO_SURFACE_TYPE_XCB:
     type = &PycairoXCBSurface_Type;
     break;
 #endif
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if defined(CAIRO_HAS_XLIB_SURFACE) && !defined(PYCAIRO_NO_X11)
   case CAIRO_SURFACE_TYPE_XLIB:
     type = &PycairoXlibSurface_Type;
     break;
@@ -2314,7 +2314,7 @@ PyTypeObject PycairoWin32PrintingSurface_Type = {
 
 
 /* Class XCBSurface(Surface) --------------------------------------------- */
-#ifdef CAIRO_HAS_XCB_SURFACE
+#if defined(CAIRO_HAS_XCB_SURFACE) && !defined(PYCAIRO_NO_X11)
 #include <cairo-xcb.h>
 
 static PyObject *
@@ -2382,11 +2382,11 @@ PyTypeObject PycairoXCBSurface_Type = {
   0,                                  /* tp_is_gc */
   0,                                  /* tp_bases */
 };
-#endif  /* CAIRO_HAS_XCB_SURFACE */
+#endif  /* defined(CAIRO_HAS_XCB_SURFACE) && !defined(PYCAIRO_NO_X11) */
 
 
 /* Class XlibSurface(Surface) --------------------------------------------- */
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if defined(CAIRO_HAS_XLIB_SURFACE) && !defined(PYCAIRO_NO_X11)
 #include <cairo-xlib.h>
 
 static PyObject *
@@ -2461,7 +2461,7 @@ PyTypeObject PycairoXlibSurface_Type = {
   0,                                  /* tp_is_gc */
   0,                                  /* tp_bases */
 };
-#endif  /* CAIRO_HAS_XLIB_SURFACE */
+#endif  /* defined(CAIRO_HAS_XLIB_SURFACE) && !defined(PYCAIRO_NO_X11) */
 
 #ifdef CAIRO_HAS_TEE_SURFACE
 #include <cairo-tee.h>

--- a/meson.build
+++ b/meson.build
@@ -115,6 +115,10 @@ pyext_c_args = [
   '-DPYCAIRO_VERSION_MICRO=@0@'.format(pycairo_version_micro),
 ]
 
+if get_option('no-x11')
+  pyext_c_args += ['-DPYCAIRO_NO_X11']
+endif
+
 if not for_wheel
   pkginfo_conf = configuration_data()
   pkginfo_conf.set('VERSION', pycairo_version)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,8 @@
 option('python', type : 'string', value : 'python3')
 option('tests', type : 'boolean', value : true, description : 'build unit tests')
 option('wheel', type : 'boolean', value : false, description : 'build for a Python wheel')
+option('no-x11',
+  type: 'boolean',
+  value: false,
+  description: 'Disable X11 surface support (Xlib and XCB) even if cairo has it enabled'
+)

--- a/tests/cmodule/cmodulelib.c
+++ b/tests/cmodule/cmodulelib.c
@@ -226,14 +226,14 @@ test_capi (PyObject *self, PyObject *args)
     #endif
 
     // PycairoXCBSurface_Type
-    #ifdef CAIRO_HAS_XCB_SURFACE
+    #if defined(CAIRO_HAS_XCB_SURFACE) && !defined(PYCAIRO_NO_X11)
     if(PyType_Ready(&PycairoXCBSurface_Type) != 0) {
         return NULL;
     }
     #endif
 
     // PycairoXlibSurface_Type
-    #ifdef CAIRO_HAS_XLIB_SURFACE
+    #if defined(CAIRO_HAS_XLIB_SURFACE) && !defined(PYCAIRO_NO_X11)
     if(PyType_Ready(&PycairoXlibSurface_Type) != 0) {
         return NULL;
     }


### PR DESCRIPTION
This avoids using any of the xlib and xcb APIs provided by cairo as if cairo was not built with support for those.

This is to allow downstream to provide non-x cairo builds, and a pycairo build that works with both cairo variants.

PR #421 is a more dynamic solution for this problem, but this is easier and less risky for now.

See #420