### PR TITLE
cairo-win32: update to 1.18.4-v3

### DIFF
--- a/.ci/download-cairo-win32.py
+++ b/.ci/download-cairo-win32.py
@@ -10,7 +10,7 @@ import zipfile
 from pathlib import Path
 from urllib.request import urlretrieve as download
 
-CAIRO_VERSION = "1.18.4-v2"
+CAIRO_VERSION = "1.18.4-v3"
 
 
 def get_platform() -> str:


### PR DESCRIPTION
https://github.com/pygobject/cairo-win-build/releases/tag/1.18.4-v3