### PR TITLE
CI: test with 3.15 + build wheels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', 'pypy-3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', '3.15', '3.15t', 'pypy-3.11']
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -97,7 +97,7 @@ jobs:
         uv sync
 
     - name: Install optional test dependencies
-      if: ${{ !contains(matrix.python-version, 'pypy') && !contains(matrix.python-version, '3.14') }}
+      if: ${{ !contains(matrix.python-version, 'pypy') && !contains(matrix.python-version, '3.14') && !contains(matrix.python-version, '3.15') }}
       run: |
         uv sync --group test-extras
 
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', 'pypy-3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', '3.15', '3.15t', 'pypy-3.11']
         architecture: ['x64']
         os: ['windows-2022']
         include:
@@ -148,7 +148,7 @@ jobs:
           - python-version: '3.14'
             architecture: 'x86'
             os: 'windows-2022'
-          - python-version: '3.14'
+          - python-version: '3.15'
             architecture: 'arm64'
             os: 'windows-11-arm'
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -70,8 +70,8 @@ jobs:
         env:
           CFLAGS: "-DCAIRO_WIN32_STATIC_BUILD=1"
           CIBW_BEFORE_BUILD: "python {package}/.ci/download-cairo-win32.py ${{ matrix.arch }}"
-          CIBW_BUILD: cp310-${{ matrix.platform_id }} cp311-${{ matrix.platform_id }} cp312-${{ matrix.platform_id }} cp313-${{ matrix.platform_id }} cp314-${{ matrix.platform_id }} cp314t-${{ matrix.platform_id }}
-          CIBW_SKIP: cp314t-win32
+          CIBW_BUILD: cp310-${{ matrix.platform_id }} cp311-${{ matrix.platform_id }} cp312-${{ matrix.platform_id }} cp313-${{ matrix.platform_id }} cp314-${{ matrix.platform_id }} cp314t-${{ matrix.platform_id }} cp315-${{ matrix.platform_id }} cp315t-${{ matrix.platform_id }}
+          CIBW_SKIP: cp314t-win32 cp315-win32 cp315t-win32
           CIBW_TEST_REQUIRES: pytest==8.3.5
           CIBW_TEST_COMMAND: bash {package}/.ci/test-wheels.sh {package}
           CIBW_ENVIRONMENT_WINDOWS: PKG_CONFIG_PATH='${{ github.workspace }}/cairo-prebuild/lib/pkgconfig' PKG_CONFIG='${{ github.workspace }}/cairo-prebuild/bin/pkgconf.exe'


### PR DESCRIPTION
Stop bulding wheels for 32bit windows for 3.15, let's see if anyone complains.